### PR TITLE
Accommodate intel-oneapi compilers like

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -17,7 +17,7 @@ export ENVIRONMENT=jed
 
 # Variables read from commons.yaml using cat, grep and cut.
 #export WORK_DIR=`cat ${BASE_DIR}/stacks/${STACK}/common.yaml |grep work_directory: | cut -n -d " " -f 2`
-export WORK_DIR=/scratch/richart/spack
+export WORK_DIR=/scratch/syrah/run/pr
 
 # Because this script is adapted from the Jenkins Pipeline, the environment
 # names must be pulled from a variable called NODE_LABELS. This variable only
@@ -29,7 +29,7 @@ export JENKINS=jenkins/deploy/scripts
 
 if [[ $option = "setupenv" ]]; then
     echo "program stopped after exporting all variables to environment"
-    return
+    exit
 fi
 
 LOGS=${WORK_DIR}/logs
@@ -118,7 +118,7 @@ ${JENKINS}/concretize.sh 2>&1 | tee ${LOGS}/07_concretize.${execution_timestamp}
 
 if [[ $option = "concretize" ]]; then
     echo "program stopped at concretization step"
-    return
+    exit
 fi
 
 echo '  _________________________________________    ______  '
@@ -150,6 +150,18 @@ echo ' /        \  |    |    |        \ |    |      |   \  \_/   \'
 echo '/_______  /  |____|   /_______  / |____|      |___|\_____  /'
 echo '        \/                    \/                         \/ '
 echo
+echo '> create_modules.sh'
+echo
+${JENKINS}/create_modules.sh 2>&1 | tee ${LOGS}/10_create_modules.${execution_timestamp}.log
+
+echo '  _________________________________________   ____ ____ '
+echo ' /   _____/\__    ___/\_   _____/\______   \ /_   /_   |'
+echo ' \_____  \   |    |    |    __)_  |     ___/  |   ||   |'
+echo ' /        \  |    |    |        \ |    |      |   ||   |'
+echo '/_______  /  |____|   /_______  / |____|      |___||___|'
+echo '        \/                    \/                        '
+echo
 echo '> activate_packages.sh'
 echo
-${JENKINS}/activate_packages.sh 2>&1 | tee ${LOGS}/10_activate_packages.${execution_timestamp}.log
+${JENKINS}/activate_packages.sh 2>&1 | tee ${LOGS}/11_activate_packages.${execution_timestamp}.log
+

--- a/jenkins/deploy/scripts/create_modules.sh
+++ b/jenkins/deploy/scripts/create_modules.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -l
+set -euo pipefail
+
+# Activating Spack
+. $JENKINS/activate_spack.sh
+
+# Gather values
+LMOD_PREFIX=`yareed -file stacks/${STACK_RELEASE}/common.yaml -keys modules roots lmod`
+LMOD_SUBDIR=`yareed -file stacks/${STACK_RELEASE}/platforms/${environment}.yaml -keys platform tokens lmod_root`
+ARCH=`yareed -file stacks/${STACK_RELEASE}/platforms/${environment}.yaml -keys platform tokens lmod_arch`
+COMPILER=`yareed -file stacks/${STACK_RELEASE}/${STACK_RELEASE}.yaml -keys intel stable compiler |awk -F'@' '{print $1}'`
+COMPILER_VER=`yareed -file stacks/${STACK_RELEASE}/${STACK_RELEASE}.yaml -keys intel stable compiler |awk -F'@' '{print $2}'`
+COMPILER_SPEC=`yareed -file stacks/${STACK_RELEASE}/${STACK_RELEASE}.yaml -keys intel stable compiler_spec |awk -F'@' '{print $1}'`
+COMPILER_SPEC_VER=`yareed -file stacks/${STACK_RELEASE}/${STACK_RELEASE}.yaml -keys intel stable compiler_spec |awk -F'@' '{print $2}'`
+
+# Compose values
+LMOD_CORE=$STACK_PREFIX/$STACK_RELEASE_VER/$LMOD_PREFIX/${LMOD_SUBDIR}/${ARCH}/Core
+LMOD_INTEL=$STACK_PREFIX/$STACK_RELEASE_VER/$LMOD_PREFIX/${LMOD_SUBDIR}/${ARCH}/intel
+
+# Show final values
+echo "LMOD_CORE: $LMOD_CORE"
+echo "LMOD_INTEL: $LMOD_INTEL"
+echo "COMPILER: $COMPILER"
+echo "COMPILER_VER: $COMPILER_VER"
+echo "COMPILER_SPEC: $COMPILER_SPEC"
+echo "COMPILER_SPEC_VER: $COMPILER_SPEC_VER"
+
+echo "Creating modules"
+# we can pass -e ${environment} to the spack command
+spack module lmod refresh -y
+
+# What's happening ?
+# ----------------
+# step 1: create the new module
+# step 2: add the missing directives to the new module
+# step 3: backup the old module
+
+# step 1
+cp -r ${LMOD_CORE}/${COMPILER_SPEC} ${LMOD_CORE}/intel
+
+# step 2
+cat >> ${LMOD_CORE}/${COMPILER}/${COMPILER_VER}.lua<<EOL
+-- Services provided by the package
+family("compiler")
+
+-- Loading this module unlocks the path below unconditionally
+prepend_path("MODULEPATH", "${LMOD_INTEL}/${COMPILER_VER}")
+EOL
+
+# step 3
+mv ${LMOD_CORE}/${COMPILER_SPEC}/${COMPILER_SPEC_VER}.lua ${LMOD_CORE}/${COMPILER_SPEC}/${COMPILER_SPEC_VER}.lua.bckp

--- a/jenkins/deploy/scripts/install_compilers_parallel.sh
+++ b/jenkins/deploy/scripts/install_compilers_parallel.sh
@@ -27,7 +27,7 @@ do
     spec_path=$(spack location -i ${spec})
     echo "spack compiler find --scope system ${spec_path} || true"
 
-    if [[ "$spec" =~ "intel" ]]; then
+    if [[ "$spec" =~ "intel@" ]]; then
 	compiler_add=1
 	if [ -e ${SPACK_SYSTEM_CONFIG_PATH}/compilers.yaml ]; then
 	    grep -q ${spec_path} ${SPACK_SYSTEM_CONFIG_PATH}/compilers.yaml

--- a/jenkins/deploy/scripts/install_stack.sh
+++ b/jenkins/deploy/scripts/install_stack.sh
@@ -7,5 +7,6 @@ set -euo pipefail
 echo "Installing packages for environment ${environment}"
 spack --env ${environment} install --log-format junit --log-file install_stack.xml
 
-echo "Creating modules for environment ${environment}"
-spack --env ${environment} module lmod refresh -y
+# Modules are now created in next step 
+#echo "Creating modules for environment ${environment}"
+#spack --env ${environment} module lmod refresh -y

--- a/sdploy/read_compilers.py
+++ b/sdploy/read_compilers.py
@@ -36,7 +36,13 @@ class Compilers(StackFile):
         compilers = []
         for pe, stack in compilers_data.items():
             for stack_name, stack in stack.items():
-                if 'compiler' in stack:
+                # The order is important:
+                # - compiler_spec has priority over compiler
+                if 'compiler_spec' in stack:
+                    compilers.append('{} %{}'.format(stack['compiler_spec'], core_compiler))
+                elif 'compiler' in stack:
                     compilers.append('{} %{}'.format(stack['compiler'], core_compiler))
+                else:
+                    print(f'No compiler found for PE {pe} {stack_name}')
 
         return compilers

--- a/sdploy/spack_yaml.py
+++ b/sdploy/spack_yaml.py
@@ -63,8 +63,11 @@ class SpackYaml(StackFile):
         for pe, stack in data.items():
             for stack_name in stack.keys():
                 self.pe_specs[pe + '_' + stack_name] = list(stack[stack_name].keys())
-                # compiler is defined by default
-                self.pe_specs[pe + '_' + stack_name].pop(0)
+                # Remove compilers
+                if 'compiler' in self.pe_specs[pe + '_' + stack_name]:
+                    self.pe_specs[pe + '_' + stack_name].remove('compiler')
+                if 'compiler_spec' in self.pe_specs[pe + '_' + stack_name]:
+                    self.pe_specs[pe + '_' + stack_name].remove('compiler_spec')
 
     def create_pe_definitions_dict(self, filter = 1, core = True):
         """Regroup PE definitions in a single dictionary"""

--- a/stacks/syrah/platforms/jed.yaml
+++ b/stacks/syrah/platforms/jed.yaml
@@ -8,6 +8,7 @@ platform:
     target: icelake
     os: rhel8
     lmod_root: jed
+    lmod_arch: linux-rhel8-x86_64
     jdk_version: 1.8.0_332
     slurm_version: 22-05-6
     core_per_socket: 36

--- a/stacks/syrah/templates/spack.yaml.j2
+++ b/stacks/syrah/templates/spack.yaml.j2
@@ -38,9 +38,6 @@ spack:
 {#                                                          #}
 {#                                                          #}
 {% for pe, stack in data['pe_specs'].items() %}
-  - matrix:
-    - [ ${{ pe }}_compiler]
-    - [ $%core_compiler ]
 {% for library in stack %}
   - matrix:
     - [ ${{ pe }}_{{ library }} ]


### PR DESCRIPTION
This PR comes to fix two problems. The first problem is that the spec intel-oneapi-compilers-classic does not install a compiler with its name. Because of this, the manifest file will refer to compilers that do not exist.

To adress this problem, this PR introduces a new concept: compiler_spec. This is a new keyword that can be used in the stack file, in the PE section, along side with the compiler keyword. Here we are saying that we want to install the package `compiler_spec`, but use the compiler `compiler` in the matrix specs.

The following changes were made to achieve this:

+ Change spack list-compilers command to return `compiler_spec` instead of `compiler` if found ;
+ Remove compilers from `pe_specs` dictionary in `SpackYaml` class ;
+ Update `modules.ymal.j2` template accordingly ;
+ Add `@` symbol to test in intall compilers script to bypass `intel-oneapi` like compilers.

The next problem that this PR resolves is that the `compiler_spec` which has provided `compiler` do not load the modules compiled by `compiler`. This is a [known issue](https://github.com/spack/spack/issues/30608) that has not integrated v0.18.1
of spack. Mainly this happens because the module file generated does not contain two directives that are mandatory for the Lmod hierarchy works:

```bash
family("compilers")
prepend_path("MODULEPATH", "/path/to/intel/modules")
```

The following changes were made to achieve this:

+ The script of step 9 - install stack - was separated in two. The new script will only handle the module creation.
+ This new script creates a new module called `compiler` with the missing directives and hides the module generated by spack.

The `init.sh` script was adapted, but not the jenkins pipeline. 

All tests were done using the following stack:

```yaml
core:
  metadata:
    section: core
  compiler: <core_compiler>

gcc:
  metadata:
    section: pe
  stable:
    compiler: gcc@11.3.0

intel:
  metadata:
    section: pe
  stable:
    compiler: intel@2021.6.0
    compiler_spec: intel-oneapi-compilers-classic@2021.6.0

benchmarks:
  metadata: { section: packages }
  pe: [gcc_stable, intel_stable]
  packages:
    - stream
    - stream+openmp
```
Which result in the following compilers installed:

```bash
erothe-> spack compilers
==> Available compilers
-- gcc rhel8-x86_64 ---------------------------------------------
gcc@11.3.0  gcc@8.5.0

-- intel rhel8-x86_64 -------------------------------------------
intel@2021.6.0
```
And the following set of modules:

```bash
├── linux-rhel8-x86_64
    ├── gcc
    │   └── 11.3.0
    │       └── stream
    │           ├── 5.10.lua
    │           └── 5.10-openmp.lua
    └── intel
        └── 2021.6.0
            └── stream
                ├── 5.10.lua
                └── 5.10-openmp.lua
```
