### PR TITLE
Modifying the stack to add intel to the already installed gcc versio

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -14,6 +14,7 @@ set -u
 # Variables needed to run this script
 export STACK=syrah
 export ENVIRONMENT=jed
+export IN_PR=1
 
 # Variables read from commons.yaml using cat, grep and cut.
 #export WORK_DIR=`cat ${BASE_DIR}/stacks/${STACK}/common.yaml |grep work_directory: | cut -n -d " " -f 2`
@@ -165,3 +166,6 @@ echo '> activate_packages.sh'
 echo
 ${JENKINS}/activate_packages.sh 2>&1 | tee ${LOGS}/11_activate_packages.${execution_timestamp}.log
 
+${JENKINS}/create_buildcache.sh 2>&1 | tee ${LOGS}/11_create_buildcache.${execution_timestamp}.log
+
+${JENKINS}/push_buildcache.sh 2>&1 | tee ${LOGS}/12_push_buildcache.${execution_timestamp}.log

--- a/jenkins/deploy/scripts/activate_spack.sh
+++ b/jenkins/deploy/scripts/activate_spack.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 . ${JENKINS}/configure_proxies.sh
 . ${JENKINS}/setenv.sh
 
+if [ "x${IN_PR}" != "x" -a ${IN_PR} -eq 1 ]; then
+    echo "[--] Running in PR [--]"
+fi
+
 
 echo 'Activating Python virtual environment' 1>&2
 if [ -e ${PYTHON_VIRTUALENV_PATH}/bin/activate ]; then
@@ -37,4 +41,6 @@ if [ -e $SPACK_INSTALL_PATH/share/spack/setup-env.sh ]; then
         export SPACK_SYSTEM_CONFIG_PATH=${_env_path}
         echo "Setting SPACK_SYSTEM_CONFIG_PATH to: ${SPACK_SYSTEM_CONFIG_PATH}" 1>&2
     fi
+else
+    unset SPACK_SYSTEM_CONFIG_PATH
 fi

--- a/jenkins/deploy/scripts/init_environment.sh
+++ b/jenkins/deploy/scripts/init_environment.sh
@@ -58,5 +58,11 @@ mkdir -p ${STACK_PREFIX}/${STACK_RELEASE_VER}/var/spack/environments
 cd ${STACK_PREFIX}/${STACK_RELEASE_VER}/var/spack/environments
 ln -sf ${SPACK_SYSTEM_CONFIG_PATH} ${environment}
 
+echo "------------------------------------------------------------------- ${IN_PR}"
+if [ "x${IN_PR}" != "x" -a ${IN_PR} -eq 1 ]; then
+    cp ${SPACK_SDPLOY_INSTALL_PATH}/stacks/${STACK}/templates/upstreams.yaml ${SPACK_SYSTEM_CONFIG_PATH}
+    cp /ssoft/spack/syrah/v1/var/spack/environments/jed/spack.lock ${SPACK_SYSTEM_CONFIG_PATH}
+fi
+
 echo "List environment directory contents"
 ls -l ${SPACK_SYSTEM_CONFIG_PATH}

--- a/jenkins/deploy/scripts/setenv.sh
+++ b/jenkins/deploy/scripts/setenv.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
 export WORK_DIR_INTERNAL=`cat stacks/${STACK}/common.yaml |grep work_directory: | cut -n -d " " -f 2`
-IN_PR=0
+
+set +u
+if [ "x${IN_PR}" == "x" ]; then
+    IN_PR=0
+fi
+set -u
+
 if [ WORK_DIR_INTERNAL != WORK_DIR ]; then
     IN_PR=1
 fi

--- a/stacks/syrah/platforms/jed.yaml
+++ b/stacks/syrah/platforms/jed.yaml
@@ -11,5 +11,5 @@ platform:
     lmod_arch: linux-rhel8-x86_64
     jdk_version: 1.8.0_332
     slurm_version: 22-05-6
-    core_per_socket: 36
+    core_per_socket: 72
     external_prefix: /ssoft/spack/external

--- a/stacks/syrah/syrah.yaml
+++ b/stacks/syrah/syrah.yaml
@@ -129,24 +129,18 @@ core_packages_stable:
 # ------------------------------------------------------------------------------
 serial_packages:
   metadata: { section: packages }
-  pe: [gcc_stable]
+  pe: [gcc_stable, intel_stable]
   packages:
     - bwa
     - bzip2
     - cmake ~ncurses:
         dependencies:
           - openssl@1.1.1k
-    - eigen:
-        default: { variants: +ipo }
     - fastqc
     - fftw +openmp ~mpi
     - fftw ~openmp ~mpi
     - gsl
     - gzip
-    - hdf5:
-        default:
-          version: 1.12.2
-          variants: ~mpi +cxx +fortran +hl +ipo +shared +szip +tools
     - hisat2
     - htslib
     - hwloc:
@@ -157,7 +151,7 @@ serial_packages:
               nvidia: +cuda +nvml ~rocm
               none: ~cuda ~rocm ~nvml
               amd: +rocm ~cuda
-    - intel-tbb
+    - intel-oneapi-tbb
     - jasper
     - libfabric:
         default:
@@ -178,10 +172,6 @@ serial_packages:
     #          - charmpp ~smp backend=verbs build-target=charm++ pmi=slurmpmi2
     - perl:
         default: { version: 5.32.0 }
-    # TODO: check if the reuse: True makes it use the proper node-js
-    # node-js@18.9.1 includes npm@8.19.1
-    # idea: make a new spack package with this version of npm
-    # - npm
     # This is already specified in the PE section
     # Here we are just making sure it will go into packages.yaml
     - python:
@@ -189,12 +179,6 @@ serial_packages:
         default:
           version: <python3>
           variants: +tkinter +optimizations ~debug +ssl ~libxml2
-    - ncview:
-        dependencies:
-          - hdf5 ~mpi+szip+hl+fortran+cxx
-          - netcdf-c ~mpi~parallel-netcdf
-    - netcdf-c~mpi ^hdf5~mpi+szip+hl+fortran+cxx
-    - netcdf-fortran ^netcdf-c~mpi ^hdf5~mpi+szip+hl+fortran+cxx
     - nfft ^fftw~mpi+openmp
     - openssl:
         default:
@@ -222,14 +206,15 @@ serial_packages_gcc_stable:
   metadata: { section: packages }
   pe: [gcc_stable]
   packages:
-    # The installation of intel-mkl create an empty directory in the not haswell
-    # environment, but one question remains : does loading the package from the
-    # ivybridge environment will invoke the module from haswell ?
-    - intel-mkl
+    - eigen:
+        default: { variants: +ipo }
     - ffmpeg +libx264
     - glpk+gmp
-    # julia >= 0.5 conflicts with intel compilers
-    # it is not in the serial_packages_python_gcc_stable due to the dependecy to mkl
+    - hdf5:
+        default:
+          version: 1.12.2
+          variants: ~mpi +cxx +fortran +hl +ipo +shared +szip +tools
+    - intel-mkl
     - libevent:
         default:
           buildable: false
@@ -238,6 +223,12 @@ serial_packages_gcc_stable:
             prefix: /usr
         module:
           blacklist: true
+    - ncview:
+        dependencies:
+          - hdf5 ~mpi+szip+hl+fortran+cxx
+          - netcdf-c ~mpi~parallel-netcdf
+    - netcdf-c~mpi ^hdf5~mpi+szip+hl+fortran+cxx
+    - netcdf-fortran ^netcdf-c~mpi ^hdf5~mpi+szip+hl+fortran+cxx
     - pmix:
         default:
           buildable: False
@@ -250,6 +241,7 @@ serial_packages_gcc_stable:
         externals:
           - spec: rdma-core@40.1
             prefix: /usr
+#    - rust
     - slurm:
         default:
           buildable: false
@@ -262,6 +254,19 @@ serial_packages_gcc_stable:
           variants:
             common: +rdmacm +rc +dc +ud +cm +cma +verbs +mlx5_dv +parameter_checking +thread_multiple
 
+
+# INTEL ONLY ---------------------------------------------------------------------
+#
+#
+# ------------------------------------------------------------------------------
+serial_packages_intel_stable:
+  metadata: { section: packages }
+  pe: [intel_stable]
+  packages:
+    - eigen ~ipo
+    - hdf5~ipo
+    - netcdf-c~mpi ^hdf5~ipo~mpi+szip+hl+fortran+cxx
+    - netcdf-fortran ^netcdf-c~mpi ^hdf5~ipo~mpi+szip+hl+fortran+cxx
 
 # GPU --------------------------------------------------------------------------
 #
@@ -284,8 +289,7 @@ serial_packages_gcc_stable:
 serial_packages_blas:
   metadata:
     section: packages
-  pe:
-    - gcc_stable
+  pe: [gcc_stable, intel_stable]
   dependencies:
     - blas
   packages:
@@ -299,7 +303,7 @@ serial_packages_blas:
 # ------------------------------------------------------------------------------
 serial_packages_blas_gpu:
   metadata: { section: packages }
-  pe: [gcc_stable]
+  pe: [gcc_stable, intel_stable]
   dependencies: [blas, gpu]
   packages:
     - suite-sparse:
@@ -334,7 +338,7 @@ serial_packages_python_activated:
     modules:
       blacklist: True
     activated: True
-  pe: [gcc_stable]
+  pe: [gcc_stable, intel_stable]
   dependencies: [python3]
   packages:
     - py-absl-py
@@ -342,7 +346,6 @@ serial_packages_python_activated:
     - py-cython
     - py-gast
     - py-google-pasta
-    - py-grpcio
     - py-pip
     - py-ply
     - py-protobuf
@@ -364,7 +367,7 @@ serial_packages_python_blas_activated:
     section: packages
     modules: { blacklist: True }
     activated: True
-  pe: [gcc_stable]
+  pe: [gcc_stable, intel_stable]
   dependencies: [python3, blas_parallel]
   packages:
     - py-keras-preprocessing
@@ -372,7 +375,6 @@ serial_packages_python_blas_activated:
     - py-numpy
     - py-opt-einsum
     - py-pandas
-    - py-scipy
     - py-xarray
 
 # PYTHON -----------------------------------------------------------------------
@@ -382,14 +384,28 @@ serial_packages_python_blas_activated:
 serial_packages_python:
   metadata:
     section: packages
-  pe: [gcc_stable]
+  pe: [gcc_stable, intel_stable]
   dependencies: [python3]
   packages:
-    - angsd
     - bedtools2
     - bowtie2
     - cairo:
         default: { variants: +png +pdf +fc +ft }
+    - mercurial
+    - ninja
+    - prinseq-lite
+    - py-pybind11
+    - samtools
+    - scons
+    - snakemake
+
+serial_packages_python_gcc_stable:
+  metadata:
+    section: packages
+  pe: [gcc_stable]
+  dependencies: [python3]
+  packages:
+    - angsd
     - llvm@14.0.6:
         default:
           version: 14.0.6
@@ -398,16 +414,29 @@ serial_packages_python:
             gpu:
               nvidia: +cuda cuda_arch=<cuda_arch>
               none: ~cuda
-    - mercurial
-    - ninja
-    - prinseq-lite
+    - py-grpcio:
+       activated: True
     - py-h5py ^hdf5~mpi:
         modules:
           autoload: direct
-    - py-pybind11
-    - samtools
-    - scons
-    - snakemake
+
+serial_packages_python_intel_stable:
+  metadata:
+    section: packages
+  pe: [intel_stable]
+  dependencies: [python3]
+  packages:
+    - py-h5py ^hdf5~mpi~ipo:
+        modules:
+          autoload: direct
+    # - llvm@14.0.6:
+    #     default:
+    #       version: 14.0.6
+    #       variants:
+    #         common: ~ipo ~internal_unwind
+    #         gpu:
+    #           nvidia: +cuda cuda_arch=<cuda_arch>
+    #           none: ~cuda
 
 # PYTHON BLAS ------------------------------------------------------------------
 #
@@ -415,13 +444,23 @@ serial_packages_python:
 # ------------------------------------------------------------------------------
 serial_packages_python_blas:
   metadata: { section: packages }
-  pe: [gcc_stable]
+  pe: [gcc_stable, intel_stable]
   dependencies: [python3, blas_parallel]
   packages:
     - boost:
         default:
           variants: cxxstd=14 +icu ~mpi +python +numpy +atomic +chrono +container +date_time +filesystem +graph +iostreams ~json +locale +log +math ~pic +program_options +random +regex +serialization +shared +signals ~singlethreaded ~stacktrace +system ~taggedlayout +test +thread +timer ~type_erasure ~versionedlayout +wave +exception
     #- bcl2fastq2
+    - py-biopython
+    #- py-keras ^py-h5py ^hdf5 ~mpi
+    - py-macs2
+    - py-pybigwig
+
+serial_packages_python_blas_gcc_stable:
+  metadata: { section: packages }
+  pe: [gcc_stable]
+  dependencies: [python3, blas_parallel]
+  packages:
     - gmsh:
         variants: |
           ~mpi +hdf5 +cgns +eigen ~opencascade +openmp ~fltk ~med
@@ -433,29 +472,32 @@ serial_packages_python_blas:
     - iq-tree +ipo@1.6.12
     - iq-tree +ipo@2.0.6
     - polymake
-    - py-biopython
     - py-deeptools
-    #- py-keras ^py-h5py ^hdf5 ~mpi
-    - py-macs2
-    - py-pybigwig
     - py-scikit-learn
+    - py-scipy
     - py-statsmodels
-
-
-# PYTHON BLAS GPU --------------------------------------------------------------
-#
-#
-# ------------------------------------------------------------------------------
-serial_packages_python_blas_gpu:
-  metadata: { section: packages }
-  pe: [gcc_stable]
-  dependencies: [blas_parallel, python3, gpu]
-  packages:
     - py-theano:
         variants:
           gpu:
             nvidia: +cuda cuda_arch=<cuda_arch>
             none: ~cuda
+
+serial_packages_python_blas_intel_stable:
+  metadata: { section: packages }
+  pe: [intel_stable]
+  dependencies: [python3, blas_parallel]
+  packages:
+    - gmsh:
+        variants: |
+          ~mpi +hdf5 +cgns +eigen ~opencascade +openmp ~fltk ~med
+        dependencies:
+          - scotch ~mpi
+          - cgns ~mpi
+          - hdf5 ~mpi ~ipo
+          - mmg ~ipo ~vtk
+    - iq-tree ~ipo@1.6.12
+    - iq-tree ~ipo@2.0.6
+
 
 # PYTHON 2 ---------------------------------------------------------------------
 #
@@ -463,7 +505,7 @@ serial_packages_python_blas_gpu:
 # ------------------------------------------------------------------------------
 serial_packages_python2_deprecated:
   metadata: { section: packages }
-  pe: [gcc_stable]
+  pe: [gcc_stable, intel_stable]
   dependencies: [python2]
   packages:
     - jellyfish
@@ -661,8 +703,7 @@ external_packages:
 mpi_packages:
   metadata:
     section: packages
-  pe:
-    - gcc_stable
+  pe: [gcc_stable, intel_stable]
   dependencies:
     - mpi
   packages:
@@ -671,12 +712,7 @@ mpi_packages:
     - fftw:
         variants: +mpi +openmp
         default: { variants: +mpi ~openmp }
-    - hdf5 +mpi +szip +hl +fortran +cxx
-    - netcdf-c +mpi ^hdf5 +mpi +szip +hl +fortran +cxx
-    - netcdf-fortran ^hdf5 +mpi +szip +hl +fortran +cxx
     - openfoam-org +metis ^scotch+mpi
-    - parmetis:
-        default: { variants: +ipo }
     - phylobayesmpi
     - scotch +mpi
     #- vasp@5.4.4:
@@ -685,6 +721,40 @@ mpi_packages:
     #      permissions:
     #        read: group
     #        group: vasp-soft
+
+# MPI --------------------------------------------------------------------------
+#
+#
+# ------------------------------------------------------------------------------
+mpi_packages_gcc_stable:
+  metadata:
+    section: packages
+  pe: [gcc_stable]
+  dependencies:
+    - mpi
+  packages:
+    - hdf5 +mpi +szip +hl +fortran +cxx
+    - netcdf-c +mpi ^hdf5 +mpi +szip +hl +fortran +cxx
+    - netcdf-fortran ^hdf5 +mpi +szip +hl +fortran +cxx
+    - parmetis:
+        default: { variants: +ipo }
+
+# MPI --------------------------------------------------------------------------
+#
+#
+# ------------------------------------------------------------------------------
+mpi_packages_intel_stable:
+  metadata:
+    section: packages
+  pe: [intel_stable]
+  dependencies:
+    - mpi
+  packages:
+    - hdf5 ~ipo +mpi +szip +hl +fortran +cxx
+    - netcdf-c +mpi ^hdf5 ~ipo +mpi +szip +hl +fortran +cxx
+    - netcdf-fortran ^hdf5 ~ipo +mpi +szip +hl +fortran +cxx
+    - parmetis:
+        default: { variants: ~ipo }
 
 # MPI + BLAS -------------------------------------------------------------------
 #
@@ -703,6 +773,10 @@ mpi_blas_packages_gcc_stable:
     #     dependencies:
     #       - hdf5 +mpi
     #       - netcdf-c +mpi
+    - gmsh +mpi +eigen +openmp +hdf5 ~fltk ~opencascade ~med:
+        dependencies:
+          - hdf5 +mpi
+          - mmg +ipo ~vtk
     - cpmd@4.3 ~openmp
     - elmerfem +mumps +openmp +hypre:
         dependencies:
@@ -714,45 +788,8 @@ mpi_blas_packages_gcc_stable:
           - netlib-scalapack
     - netlib-scalapack:
         default: { variants: +ipo }
-    - yambo+mpi io=iotk,etsf-io ^fftw+mpi+openmp
-
-# MPI + BLAS ------------------------------------------------------------------
-#
-#
-# ------------------------------------------------------------------------------
-mpi_lapack_packages:
-  metadata: { section: packages }
-  pe: [gcc_stable]
-  dependencies: [mpi, blas]
-  packages:
-    - gmsh +mpi +eigen +openmp +hdf5 ~fltk ~opencascade ~med:
-        dependencies:
-          - hdf5 +mpi
-          - mmg +ipo ~vtk
     - quantum-espresso+mpi+scalapack ^fftw+mpi+openmp
     - quantum-espresso+mpi+scalapack hdf5=parallel ^fftw+mpi+openmp
-    # - molpro:
-    #     default:
-    #       buildable: true
-    #       permissions:
-    #         read: group
-    #         group: molpro-soft
-
-# MPI + BLAS + GPU -------------------------------------------------------------
-#
-#
-# ------------------------------------------------------------------------------
-mpi_lapack_gpu_packages:
-  metadata: { section: packages }
-  pe: [gcc_stable]
-  dependencies: [gpu, mpi, blas]
-  packages:
-    - hypre:
-        default:
-          variants:
-            gpu:
-              nvidia: +cuda
-              none: ~cuda
     - superlu-dist:
         default:
           variants:
@@ -760,6 +797,56 @@ mpi_lapack_gpu_packages:
             gpu:
               nvidia: +cuda
               none: ~cuda
+    - yambo+mpi io=iotk,etsf-io ^fftw+mpi+openmp
+
+# MPI + BLAS ------------------------------------------------------------------
+#
+#
+# ------------------------------------------------------------------------------
+mpi_blas_packages_intel_stable:
+  metadata: { section: packages }
+  pe: [intel_stable]
+  dependencies: [mpi, blas]
+  packages:
+    - gmsh +mpi +eigen +openmp +hdf5 ~fltk ~opencascade ~med:
+        dependencies:
+          - hdf5 +mpi ~ipo
+          - mmg ~ipo ~vtk
+    - quantum-espresso+mpi+scalapack
+    - quantum-espresso+mpi+scalapack hdf5=parallel ^hdf5 ~ipo+mpi
+    - mumps:
+        default: { variants: +mpi +parmetis +metis +scotch +ptscotch }
+        dependencies:
+          - scotch +mpi
+    - superlu-dist:
+        default:
+          variants:
+            common: ~ipo
+            gpu:
+              nvidia: +cuda
+              none: ~cuda
+
+# MPI + BLAS ------------------------------------------------------------------
+#
+#
+# ------------------------------------------------------------------------------
+mpi_blas_packages:
+  metadata: { section: packages }
+  pe: [gcc_stable, intel_stable]
+  dependencies: [mpi, blas]
+  packages:
+    - hypre:
+        default:
+          variants:
+            gpu:
+              nvidia: +cuda
+              none: ~cuda
+    # - molpro:
+    #     default:
+    #       buildable: true
+    #       permissions:
+    #         read: group
+    #         group: molpro-soft
 
 # MPI PYTHON --------------------------------------------------------------------
 #
@@ -768,21 +855,35 @@ mpi_lapack_gpu_packages:
 mpi_python_packages:
   metadata:
     section: packages
+  pe: [gcc_stable, intel_stable]
+  dependencies: [mpi, python3]
+  packages:
+    - py-mpi4py
+
+mpi_python_packages_gcc_stable:
+  metadata:
+    section: packages
   pe: [gcc_stable]
   dependencies: [mpi, python3]
   packages:
     - py-h5py ^hdf5 +mpi
-    - py-mpi4py
+
+mpi_python_packages_intel_gcc:
+  metadata:
+    section: packages
+  pe: [intel_stable]
+  dependencies: [mpi, python3]
+  packages:
+    - py-h5py ^hdf5 ~ipo+mpi
 
 # MPI + BLAS + PYTHON ----------------------------------------------------------
 #
 #
 # ------------------------------------------------------------------------------
-mpi_lapack_python_packages:
+mpi_blas_python_packages:
   metadata:
     section: packages
-  pe:
-    - gcc_stable
+  pe: [gcc_stable, intel_stable]
   dependencies:
     - mpi
     - blas
@@ -795,33 +896,6 @@ mpi_lapack_python_packages:
     - neuron +mpi +python
     - plumed:
         default: { variants: +mpi +gsl }
-    - petsc:
-        default:
-          variants:
-            common:  ~int64 +double +hdf5 +metis +mpi +superlu-dist +hypre +suite-sparse
-            gpu:
-              nvidia: +cuda
-              none: ~cuda
-        dependencies:
-          - hdf5 +mpi +szip +hl +fortran +cxx
-    - slepc:
-        default: { variants: +arpack }
-    - py-petsc4py
-    - py-torch:
-        variants: +mpi
-        default:
-          variants:
-            gpu:
-              nvidia: +cuda cuda_arch=<cuda_arch> +magma
-              none: ~cuda ~cudnn ~nccl
-              rocm: +magma +rocm
-        dependencies:
-          gpu:
-            nvidia: [magma +cuda cuda_arch=<cuda_arch>]
-            rocm: [magma +rocm amdgpuarch=<amd_arch>]
-    - py-torchvision:
-        dependencies:
-          - py-torch+mpi~cuda
 
 # MPI (GCC ONLY) ---------------------------------------------------------------
 #
@@ -897,6 +971,21 @@ mpi_blas_python_packages_gcc_stable:
     #           none: ~cuda ~nccl ~rocm amdgpu_target=none cuda_arch=none
     #     dependencies:
     #       - bazel
+    - py-torch:
+        variants: +mpi
+        default:
+          variants:
+            gpu:
+              nvidia: +cuda cuda_arch=<cuda_arch> +magma
+              none: ~cuda ~cudnn ~nccl
+              rocm: +magma +rocm
+        dependencies:
+          gpu:
+            nvidia: [magma +cuda cuda_arch=<cuda_arch>]
+            rocm: [magma +rocm amdgpuarch=<amd_arch>]
+    - py-torchvision:
+        dependencies:
+          - py-torch+mpi~cuda
     - opencv +vtk +python3:
         variants:
           gpu:
@@ -914,7 +1003,6 @@ mpi_blas_python_packages_gcc_stable:
         dependencies:
           - netcdf-c +mpi
           - boost+mpi
-
 
 mpi_blas_parallel_python_packages_gcc_stable:
   metadata: { section: packages }
@@ -946,20 +1034,43 @@ mpi_blas_parallel_python_packages_gcc_stable:
           - boost+mpi
           - fftw+mpi+openmp
 
+mpi_blas_python_packages_intel_stable:
+  metadata: { section: packages }
+  pe: [intel_stable]
+  dependencies: [mpi, blas, python3]
+  packages:
+    - petsc:
+        default:
+          variants:
+            common:  ~int64 +double +hdf5 +metis +mpi +superlu-dist +hypre +suite-sparse
+            gpu:
+              nvidia: +cuda
+              none: ~cuda
+        dependencies:
+          - hdf5 ~ipo +mpi +szip +hl +fortran +cxx
+    - slepc:
+        default: { variants: +arpack }
+        dependencies:
+          - hdf5 ~ipo +mpi +szip +hl +fortran +cxx
+    - py-petsc4py:
+        dependencies:
+          - hdf5 ~ipo +mpi +szip +hl +fortran +cxx
+
+
 # BENCHMARKS -------------------------------------------------------------------
 #
 #
 # ------------------------------------------------------------------------------
 benchmarks:
   metadata: { section: packages }
-  pe: [gcc_stable]
+  pe: [gcc_stable, intel_stable]
   packages:
     - stream
     - stream+openmp
 
 mpi_benchmarks:
   metadata: { section: packages }
-  pe: [gcc_stable]
+  pe: [gcc_stable, intel_stable]
   dependencies: [mpi]
   packages:
     - osu-micro-benchmarks
@@ -967,7 +1078,7 @@ mpi_benchmarks:
 
 mpi_blas_benchmarks:
   metadata: { section: packages }
-  pe: [gcc_stable]
+  pe: [gcc_stable, intel_stable]
   dependencies: [mpi, blas]
   packages:
     - hpl~openmp

--- a/stacks/syrah/templates/upstreams.yaml
+++ b/stacks/syrah/templates/upstreams.yaml
@@ -1,0 +1,3 @@
+upstreams:
+  syrah:
+    install_tree: /ssoft/spack/syrah/v1/opt/spack


### PR DESCRIPTION
This was tested with the `init.sh` script with the variable `IN_PR=1`
This sets the install stack as `upstream` and copies the existing `spack.lock`