### PR TITLE
Fix intel module creation mechanism

### DIFF
--- a/jenkins/deploy/scripts/create_modules.sh
+++ b/jenkins/deploy/scripts/create_modules.sh
@@ -31,12 +31,16 @@ spack module lmod refresh -y
 
 # What's happening ?
 # ----------------
-# step 1: create the new module
+# step 0: make sure the directory `intel` exists (or create it)
+# step 1: copy the module created for `intel-oneapi-compiler-classic` into `intel` directory
 # step 2: add the missing directives to the new module
 # step 3: backup the old module
 
+# step 0
+mkdir -p ${LMOD_CORE}/intel
+
 # step 1
-cp -r ${LMOD_CORE}/${COMPILER_SPEC} ${LMOD_CORE}/intel
+cp -f ${LMOD_CORE}/${COMPILER_SPEC}/${COMPILER_SPEC_VER}.lua ${LMOD_CORE}/${COMPILER}/${COMPILER_VER}.lua
 
 # step 2
 cat >> ${LMOD_CORE}/${COMPILER}/${COMPILER_VER}.lua<<EOL

--- a/stacks/syrah/templates/modules.yaml.j2
+++ b/stacks/syrah/templates/modules.yaml.j2
@@ -131,6 +131,10 @@ modules:
           set:
             HDF5_CC: h5pcc
             HDF5_FC: h5pfc
+      intel-oneapi-compilers-classic:
+        environment:
+          set:
+            INTEL_ROOT: ${PREFIX}
       intel-mpi:
         environment:
           set:

--- a/stacks/syrah/templates/modules.yaml.j2
+++ b/stacks/syrah/templates/modules.yaml.j2
@@ -135,7 +135,7 @@ modules:
         environment:
           set:
             INTEL_ROOT: ${PREFIX}
-      intel-mpi:
+      intel-oneapi-mpi:
         environment:
           set:
             I_MPI_PMI_LIBRARY: /usr/lib64/libpmi2.so


### PR DESCRIPTION
The old behaviour was coping the `intel-oneapi-compilers-classic` into the `intel` directory when the script would run for the second time.

This PR also adds a new environment variable INTEL_ROOT.