### PR TITLE
Set ifort configuration

### DIFF
--- a/jenkins/deploy/scripts/install_compilers_parallel.sh
+++ b/jenkins/deploy/scripts/install_compilers_parallel.sh
@@ -49,13 +49,9 @@ done <<< $(cat compilers.list)
 # Hack for intel compiler.
 # We want to add the following line to ifort.cfg (overwrite).
 # -isystem/ssoft/spack/syrah/v1/opt/spack/linux-rhel8-x86_64_v2/gcc-8.5.0/intel-oneapi-compilers-classic-2021.6.0-q3mi2mylw3zyuht6p72u25ruqnpptpym/compiler/include/intel64
-DST_PRFX=`spack location -i intel-oneapi-compilers`
-DST_PATH="compiler/2022.1.0/linux/bin/intel64"
-DST_FILE="ifort.cfg"
-CNT_PRFX=`spack location -i intel-oneapi-compilers-classic`
-CNT_PATH="compiler/include/intel64"
-CONTENTS="-isystem$CNT_PRFX/$CNT_PATH"
-echo $CONTENTS > $DST_PRFX/$DST_PATH/$DST_FILE
+DST_FILE=`spack location -i intel-oneapi-compilers`/bin/ifort.cfg
+CONTENTS=`spack location -i intel-oneapi-compilers-classic`/compiler/include/intel64
+echo -isystem$CONTENTS > $DST_FILE
 
 echo "============= COMPILERS DEBUG INFO ============="
 

--- a/jenkins/deploy/scripts/install_compilers_parallel.sh
+++ b/jenkins/deploy/scripts/install_compilers_parallel.sh
@@ -46,6 +46,17 @@ do
     fi
 done <<< $(cat compilers.list)
 
+# Hack for intel compiler.
+# We want to add the following line to ifort.cfg (overwrite).
+# -isystem/ssoft/spack/syrah/v1/opt/spack/linux-rhel8-x86_64_v2/gcc-8.5.0/intel-oneapi-compilers-classic-2021.6.0-q3mi2mylw3zyuht6p72u25ruqnpptpym/compiler/include/intel64
+DST_PRFX=`spack location -i intel-oneapi-compilers`
+DST_PATH="compiler/2022.1.0/linux/bin/intel64"
+DST_FILE="ifort.cfg"
+CNT_PRFX=`spack location -i intel-oneapi-compilers-classic`
+CNT_PATH="compiler/include/intel64"
+CONTENTS="-isystem$CNT_PRFX/$CNT_PATH"
+echo $CONTENTS > $DST_PRFX/$DST_PATH/$DST_FILE
+
 echo "============= COMPILERS DEBUG INFO ============="
 
 echo "SPACK_SYSTEM_CONFIG_PATH: ${SPACK_SYSTEM_CONFIG_PATH}"

--- a/jenkins/deploy/scripts/install_compilers_parallel.sh
+++ b/jenkins/deploy/scripts/install_compilers_parallel.sh
@@ -47,11 +47,19 @@ do
 done <<< $(cat compilers.list)
 
 # Hack for intel compiler.
-# We want to add the following line to ifort.cfg (overwrite).
-# -isystem/ssoft/spack/syrah/v1/opt/spack/linux-rhel8-x86_64_v2/gcc-8.5.0/intel-oneapi-compilers-classic-2021.6.0-q3mi2mylw3zyuht6p72u25ruqnpptpym/compiler/include/intel64
-DST_FILE=`spack location -i intel-oneapi-compilers`/bin/ifort.cfg
-CONTENTS=`spack location -i intel-oneapi-compilers-classic`/compiler/include/intel64
-echo -isystem$CONTENTS > $DST_FILE
+#  >>> to modify the following files: ifort.cfg, icc.cfg and icpc.cfg.
+#  files location: intel-oneapi-compilers-2022.1.0-67zhngwawhy57xzjpoc5mwbj6vzsk6jp/compiler/2022.1.0/linux/bin/intel64
+#  ifort.cfg (overwrite): 
+#  -isystem/ssoft/spack/syrah/v1/opt/spack/linux-rhel8-x86_64_v2/gcc-8.5.0/intel-oneapi-compilers-classic-2021.6.0-q3mi2mylw3zyuht6p72u25ruqnpptpym/compiler/include/intel64
+#  icc.cfg/icpc.cfg (overwrite):
+#  -isystem/ssoft/spack/syrah/v1/opt/spack/linux-rhel8-x86_64_v2/gcc-8.5.0/intel-oneapi-compilers-classic-2021.6.0-q3mi2mylw3zyuht6p72u25ruqnpptpym/compiler/include/icc
+
+DST_DIR=`spack location -i intel-oneapi-compilers`/compiler/2022.1.0/linux/bin/intel64
+CONTENT=`spack location -i intel-oneapi-compilers-classic`/compiler/include
+echo -isystem$CONTENT/intel64 > $DST_DIR/ifort.cfg
+echo -isystem$CONTENT/icc > $DST_DIR/icc.cfg
+echo -isystem$CONTENT/icc > $DST_DIR/icpc.cfg
+# ~end of hack~
 
 echo "============= COMPILERS DEBUG INFO ============="
 


### PR DESCRIPTION
Add the following line to `ifort.cfg`:
```
-isystem/ssoft/spack/syrah/v1/opt/spack/linux-rhel8-x86_64_v2/gcc-8.5.0/intel-oneapi-compilers-classic-2021.6.0-q3mi2mylw3zyuht6p72u25ruqnpptpym/compiler/include/intel64
```
ifort.cfg is located in 