### PR TITLE
Add quantum-espresso %intel

### DIFF
--- a/stacks/syrah/syrah.yaml
+++ b/stacks/syrah/syrah.yaml
@@ -813,7 +813,7 @@ mpi_blas_packages_intel_stable:
           - hdf5 +mpi ~ipo
           - mmg ~ipo ~vtk
     - quantum-espresso+mpi+scalapack
-    # - quantum-espresso+mpi+scalapack hdf5=parallel ^hdf5 ~ipo+mpi
+    - quantum-espresso+mpi+scalapack hdf5=parallel
     - mumps:
         default: { variants: +mpi +parmetis +metis +scotch +ptscotch }
         dependencies:


### PR DESCRIPTION
```
erothe-> spack spec -I quantum-espresso+mpi+scalapack hdf5=parallel %intel ^intel-oneapi-mpi ^intel-oneapi-mkl
Input spec
--------------------------------
 -   quantum-espresso%intel+mpi+scalapack hdf5=parallel
 -       ^intel-oneapi-mkl
 -       ^intel-oneapi-mpi

Concretized
--------------------------------
 -   quantum-espresso@7.0%intel@2021.6.0+cmake~elpa~environ+epw~gipaw~ipo~libxc+mpi~openmp+patch~qmcpack+scalapack build_type=RelWithDebInfo hdf5=parallel arch=linux-rhel8-icelake
[^]      ^cmake@3.23.1%gcc@11.3.0~doc~ncurses~ownlibs~qt build_type=Release arch=linux-rhel8-icelake
[^]          ^curl@7.83.0%gcc@11.3.0~gssapi~ldap~libidn2~librtmp~libssh~libssh2~nghttp2 libs=shared,static tls=gnutls arch=linux-rhel8-icelake
[^]              ^gnutls@3.6.15%gcc@11.3.0~guile+zlib arch=linux-rhel8-icelake
[^]                  ^gettext@0.21%gcc@11.3.0+bzip2+curses+git~libunistring+libxml2+tar+xz arch=linux-rhel8-icelake
[^]                      ^bzip2@1.0.8%gcc@11.3.0~debug~pic+shared arch=linux-rhel8-icelake
[^]                          ^diffutils@3.8%gcc@11.3.0 arch=linux-rhel8-icelake
[^]                              ^libiconv@1.16%gcc@11.3.0 libs=shared,static arch=linux-rhel8-icelake
[^]                      ^libxml2@2.9.13%gcc@11.3.0~python arch=linux-rhel8-icelake
[^]                          ^pkgconf@1.8.0%gcc@11.3.0 arch=linux-rhel8-icelake
[^]                          ^xz@5.2.5%gcc@11.3.0~pic libs=shared,static arch=linux-rhel8-icelake
[^]                          ^zlib@1.2.12%gcc@11.3.0+optimize+pic+shared patches=0d38234 arch=linux-rhel8-icelake
[^]                      ^ncurses@6.2%gcc@11.3.0~symlinks+termlib abi=none arch=linux-rhel8-icelake
[^]                      ^tar@1.34%gcc@11.3.0 zip=pigz arch=linux-rhel8-icelake
[^]                          ^pigz@2.7%gcc@11.3.0 arch=linux-rhel8-icelake
[^]                          ^zstd@1.5.2%gcc@11.3.0+programs compression=none libs=shared,static arch=linux-rhel8-icelake
[^]                  ^libidn2@2.3.0%gcc@11.3.0 arch=linux-rhel8-icelake
[^]                      ^libunistring@0.9.10%gcc@11.3.0 arch=linux-rhel8-icelake
[^]                  ^nettle@3.4.1%gcc@11.3.0 arch=linux-rhel8-icelake
[^]                      ^gmp@6.2.1%gcc@11.3.0 libs=shared,static arch=linux-rhel8-icelake
[^]                          ^autoconf@2.69%gcc@11.3.0 patches=35c4492,7793209,a49dd5b arch=linux-rhel8-icelake
[^]                              ^m4@1.4.19%gcc@11.3.0+sigsegv patches=9dc5fbd,bfdffa7 arch=linux-rhel8-icelake
[^]                                  ^libsigsegv@2.13%gcc@11.3.0 arch=linux-rhel8-icelake
[^]                              ^perl@5.32.0%gcc@11.3.0+cpanm+shared+threads arch=linux-rhel8-icelake
[^]                                  ^berkeley-db@18.1.40%gcc@11.3.0+cxx~docs+stl patches=b231fcc arch=linux-rhel8-icelake
[^]                                  ^gdbm@1.19%gcc@11.3.0 arch=linux-rhel8-icelake
[^]                                      ^readline@8.1%gcc@11.3.0 arch=linux-rhel8-icelake
[^]                          ^automake@1.16.5%gcc@11.3.0 arch=linux-rhel8-icelake
[^]                          ^libtool@2.4.7%gcc@11.3.0 arch=linux-rhel8-icelake
[^]          ^expat@2.4.8%gcc@11.3.0+libbsd arch=linux-rhel8-icelake
[^]              ^libbsd@0.11.5%gcc@11.3.0 arch=linux-rhel8-icelake
[^]                  ^libmd@1.0.4%gcc@11.3.0 arch=linux-rhel8-icelake
[^]          ^libarchive@3.5.2%gcc@11.3.0+iconv compression=bz2lib,lz4,lzma,lzo2,zlib,zstd crypto=mbedtls libs=shared,static programs=none xar=expat arch=linux-rhel8-icelake
[^]              ^lz4@1.9.3%gcc@11.3.0 libs=shared,static arch=linux-rhel8-icelake
[^]              ^lzo@2.10%gcc@11.3.0 libs=shared,static arch=linux-rhel8-icelake
[^]              ^mbedtls@2.28.0%gcc@11.3.0+pic build_type=Release libs=static arch=linux-rhel8-icelake
[^]          ^libuv@1.44.1%gcc@11.3.0 arch=linux-rhel8-icelake
[^]          ^rhash@1.4.2%gcc@11.3.0 patches=093518c,3fbfe46 arch=linux-rhel8-icelake
[^]      ^hdf5@1.12.2%intel@2021.6.0+cxx+fortran+hl~ipo~java+mpi+shared+szip~threadsafe+tools api=default build_type=RelWithDebInfo arch=linux-rhel8-icelake
[^]          ^intel-oneapi-mpi@2021.6.0%intel@2021.6.0~external-libfabric~ilp64 arch=linux-rhel8-icelake
[^]          ^libaec@1.0.6%gcc@11.3.0~ipo+shared build_type=RelWithDebInfo arch=linux-rhel8-icelake
[^]              ^cmake@3.23.1%gcc@11.3.0~doc~ncurses+ownlibs~qt build_type=Release arch=linux-rhel8-icelake
[^]                  ^openssl@1.1.1k%gcc@11.3.0~docs~shared certs=system arch=linux-rhel8-icelake
[^]          ^pkgconf@1.8.0%intel@2021.6.0 arch=linux-rhel8-icelake
[^]      ^intel-oneapi-mkl@2022.1.0%intel@2021.6.0~cluster~ilp64+shared arch=linux-rhel8-icelake
[^]          ^intel-oneapi-tbb@2021.6.0%intel@2021.6.0 arch=linux-rhel8-icelake
[^]      ^netlib-scalapack@2.2.0%intel@2021.6.0+ipo~pic+shared build_type=Release patches=072b006,1c9ce5f arch=linux-rhel8-icelake

(jed) 
[/work/scitas-ge/erothe/spack-chain/stack/quantum-espresso]   
erothe-> spack add quantum-espresso+mpi+scalapack hdf5=parallel %intel ^intel-oneapi-mpi ^intel-oneapi-mkl
==> Error: `spack add` requires an environment
  activate an environment first:
      spack env activate ENV
  or use:
      spack -e ENV add ...
(jed) 
[/work/scitas-ge/erothe/spack-chain/stack/quantum-espresso]   
erothe-> spack install quantum-espresso+mpi+scalapack hdf5=parallel %intel ^intel-oneapi-mpi ^intel-oneapi-mkl
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libiconv-1.16-5vpx6z4ezvcokdvycqtqqeenxdbyxt2v
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/pkgconf-1.8.0-menettzs6gzpqpxqekjpo7irsi7sfp25
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/xz-5.2.5-anc5uefulbvgefk3fzj3zm2ryw6esnb2
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/zlib-1.2.12-ixtisesx64oi2zppo5uuxiqu4jathsrg
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/zstd-1.5.2-3nyqfa3dhnanwcvactdfzg7oa2kpcmfp
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libsigsegv-2.13-mzvt4yblnihx6xyaxwm5oyz5lbqeeu2l
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/berkeley-db-18.1.40-alpnbg22suxiytbjn2uxrmvvtevlcwzq
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libmd-1.0.4-siuioad564z4ztbepjo7hbq6nas3w7db
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/lz4-1.9.3-njiddlassnvjmu5q25qda4ib2ueme6mi
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/lzo-2.10-55akfvwgzvw352odxvk3o5vrch4vlb3s
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/mbedtls-2.28.0-lclkhzjkudthbivd3t2bmpfvyii2my65
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libuv-1.44.1-vehuctx4jkbkmhu7zhhjzolknxuddu7s
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/rhash-1.4.2-6ezrwlepiqrlhkfaqytbs3rlxawaqhuq
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/intel-2021.6.0/intel-oneapi-mpi-2021.6.0-6mkuwtao6jyowm632fqb5bukxyf254xm
[+] /usr (external openssl-1.1.1k-6kxsucyy7nijmeyv77o7hhzj4jn5tvxh)
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/intel-2021.6.0/pkgconf-1.8.0-ttzl7dcujrkwm7zbddr4wsv2eb7hfq54
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/intel-2021.6.0/intel-oneapi-tbb-2021.6.0-if7xqicy2kgr6547el4n2yqv6ms3npdw
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libunistring-0.9.10-aza6iog4hfl4t47czzrp26katya3t7ct
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/diffutils-3.8-2mpysoexkbxz77pnjnprm2ub2zf6lhvu
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/ncurses-6.2-nrplriublvcsvw5zeanyvpk7qp6rc62m
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/pigz-2.7-yop5q6r47burby5b365nnqdvkgsahufg
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libxml2-2.9.13-24mkijs3skge5ebkvhbgohomfi4247zm
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/m4-1.4.19-7jt53ihkwtoef7cwu7rbqivzifq45dpq
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libbsd-0.11.5-xl5xnw5gqklushaidesyhyprqkiibgmf
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/cmake-3.23.1-dake4rc5v7nkaf3dfqmtolzjn3fhzpuh
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/intel-2021.6.0/intel-oneapi-mkl-2022.1.0-dtp7nj6bqavcu4or4ev3wjrva5hob7sd
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libidn2-2.3.0-dbiycnkywwz72ct2psvxnj5lnsyw2j3s
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/bzip2-1.0.8-726wwu5vgr5uyrhoqqajng74um2rve5z
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/readline-8.1-degusu7pyiwkqe4mhupw2jzmxtba2zx2
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libtool-2.4.7-6dbhncocoj6qrjtf7uwbtbst2rqhwrq4
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/expat-2.4.8-fxnlfyoah7jdpd2hb4o4sui3l3btltre
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libaec-1.0.6-moxk3fwz3eolej6etmlw4722yac7rg5k
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/tar-1.34-vdcabeo6p53kp5fhafzxvlfv7gffqgzs
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/gdbm-1.19-jivowxequdjrjdywtttdn72ud73uto42
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libarchive-3.5.2-ctm5vsyr2jffpknvjdlpv2pvybiemnlk
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/gettext-0.21-wa5ya2pgsdtxfmbgrt4xzbjoo6eepxrf
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/perl-5.32.0-mlt3ugw6opvrskkllatlejkk7xej5j2j
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/autoconf-2.69-dde4t7x4mrux6hdfo3opbv2asfgush2f
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/automake-1.16.5-mbbmkfai6cs5apensarbuwwinmhjf4qk
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/gmp-6.2.1-2sxyqyrtrhtith6xocksolgn5milxpsl
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/nettle-3.4.1-tsemgwui3ypx4qts3cor4qywf4dlzglb
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/gnutls-3.6.15-lqzh5hje5okkbhyibdsaz43iwhq2k7vi
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/curl-7.83.0-lese4dhsfoq5m5sczgpfa5hwxcwtp44z
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/cmake-3.23.1-iu2jsz76ugyfrzobjgprsd3odk4eadkv
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/intel-2021.6.0/hdf5-1.12.2-zzzj5gufyadodktq6xdrcvkgb2eazrfj
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/intel-2021.6.0/netlib-scalapack-2.2.0-ib2jejoikzyrxb7h4ockkifmgltegjku
==> Installing quantum-espresso-7.0-35zm2oilj5s66ebzdfnfbeezncnrxhzj
==> No binary for quantum-espresso-7.0-35zm2oilj5s66ebzdfnfbeezncnrxhzj found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/85/85beceb1aaa1678a49e774c085866d4612d9d64108e0ac49b23152c8622880ee.tar.gz
==> No patches needed for quantum-espresso
==> quantum-espresso: Executing phase: 'cmake'
==> quantum-espresso: Executing phase: 'build'
==> quantum-espresso: Executing phase: 'install'
```