### PR TITLE
Explicit declare packages

### DIFF
--- a/stacks/syrah/syrah.yaml
+++ b/stacks/syrah/syrah.yaml
@@ -139,6 +139,7 @@ serial_packages:
     - fastqc
     - fftw +openmp ~mpi
     - fftw ~openmp ~mpi
+    - gmp
     - gsl
     - gzip
     - hisat2
@@ -153,15 +154,18 @@ serial_packages:
               amd: +rocm ~cuda
     - intel-oneapi-tbb
     - jasper
+    - libarchive
     - libfabric:
         default:
           variants: fabrics=tcp,udp,sockets,mlx,verbs
+    - libtiff
     - libxc
     - libxml2:
         default: { version: 2.9.13 }
     - mafft
     - metis:
         default: { variants: +real64 }
+    - mpfr
     - muscle
     # ok syntax for namd
     #- namd:


### PR DESCRIPTION
Packages gmp and mpfr are already installed for both gcc and intel compilers. libarchive and libtiff will be added to the intel PE. Spack will generate module files for all packages and both PE (intel + gcc).