### PR TITLE
Adding missing python dependencies

### DIFF
--- a/stacks/syrah/syrah.yaml
+++ b/stacks/syrah/syrah.yaml
@@ -348,6 +348,8 @@ serial_packages_python_activated:
     - py-absl-py
     - py-astunparse
     - py-backports-entry-points-selectable
+    - py-certifi
+    - py-charset-normalizer
     - py-cycler
     - py-cython
     - py-distlib
@@ -355,6 +357,8 @@ serial_packages_python_activated:
     - py-gast
     - py-google-pasta
     - py-kiwisolver
+    - py-idna
+    - py-mpmath
     - py-packaging
     - py-pip
     - py-pillow
@@ -370,6 +374,7 @@ serial_packages_python_activated:
     - py-sympy
     - py-termcolor
     - py-virtualenv
+    - py-urllib3
     - py-wheel
     - py-wrapt
 

--- a/stacks/syrah/templates/modules.yaml.j2
+++ b/stacks/syrah/templates/modules.yaml.j2
@@ -58,12 +58,16 @@ modules:
         - ucx
         # === activated python packages
         - py-backports-entry-points-selectable
+        - py-certifi
+        - py-charset-normalizer
         - py-cycler
         - py-cython
         - py-distlib
         - py-filelock
+        - py-idna
         - py-kiwisolver
         - py-matplotlib
+        - py-mpmath
         - py-numpy
         - py-packaging
         - py-pandas
@@ -79,6 +83,7 @@ modules:
         - py-semver
         - py-six
         - py-sympy
+        - py-urllib3
         - py-virtualenv
         - py-xarray
         # # # # # extras for tensorflow


### PR DESCRIPTION
I added packages need for the already activated packages

They where found this way
```
$ module load gcc python
$ pip3 list --format json | jq '.[].name | sub("-";"_"; "g")' | xargs -I '{}' python -c "print(\"{}\"); import {}"
```

It is linked to #27 
