### PR TITLE
Change licence path

### DIFF
--- a/sdploy/config_yaml.py
+++ b/sdploy/config_yaml.py
@@ -76,8 +76,7 @@ class ConfigYaml(StackFile):
     def _add_license_dir(self):
         self.conf['license_dir'] = os.path.join(self.commons.data['work_directory'],
                                                 self.commons.data['stack_release'],
-                                                self.commons.data['spack_sdploy'],
-                                                'external', 'licenses')       
+                                                self.commons.data['spack_licences'])
 
     def _add_build_stage(self):
         """Add build stages section to the dictionary"""

--- a/sdploy/config_yaml.py
+++ b/sdploy/config_yaml.py
@@ -75,7 +75,7 @@ class ConfigYaml(StackFile):
 
     def _add_license_dir(self):
         self.conf['license_dir'] = os.path.join(self.commons.data['work_directory'],
-                                                self.commons.data['stack_release'],
+                                                self.commons.data['spack_external'],
                                                 self.commons.data['spack_licences'])
 
     def _add_build_stage(self):

--- a/stacks/syrah/common.yaml
+++ b/stacks/syrah/common.yaml
@@ -10,6 +10,7 @@ extensions: spack-config
 spack: spack
 spack_sdploy: spack-sdploy
 stack_version: v1
+spack_licences: licences
 
 environments: # platforms
   - jed


### PR DESCRIPTION
This PR adds a new variable spack_licences which will be used to construct the licences directory which no longer used the variable spack_sdploy.