### PR TITLE
bowtie2: explicit dependency on intel-oneapi-tbb

### DIFF
--- a/stacks/syrah/syrah.yaml
+++ b/stacks/syrah/syrah.yaml
@@ -409,7 +409,7 @@ serial_packages_python:
   dependencies: [python3]
   packages:
     - bedtools2
-    - bowtie2^intel-oneapi-tbb
+    - bowtie2 ^intel-oneapi-tbb
     - cairo:
         default: { variants: +png +pdf +fc +ft }
     - mercurial

--- a/stacks/syrah/syrah.yaml
+++ b/stacks/syrah/syrah.yaml
@@ -409,7 +409,7 @@ serial_packages_python:
   dependencies: [python3]
   packages:
     - bedtools2
-    - bowtie2
+    - bowtie2^intel-oneapi-tbb
     - cairo:
         default: { variants: +png +pdf +fc +ft }
     - mercurial


### PR DESCRIPTION
**Why**
intel-tbb compiling was failing.

**Context**
intel-tbb is a dependency from bowtie2. bowtie2 has been updated to version 2.4.5 in scitas-spack-packages.