### PR TITLE
Enables list filtering

### DIFF
--- a/sdploy/spack_yaml.py
+++ b/sdploy/spack_yaml.py
@@ -162,13 +162,12 @@ class SpackYaml(StackFile):
         here defined and if at least one has the none property, this list
         is skipped."""
 
-        _skip = False
         pkg_list_cfg = self.pkgs_stack[pkg_list_name]
         if 'filters' in pkg_list_cfg:
             for filter in pkg_list_cfg['filters']:
                 if self.filters[filter] == 'none':
-                    _skip = True
-        return _skip
+                    return True
+        return False
 
     def _flatten_dict(self, d: MutableMapping, parent_key: str = '', sep: str = '_'):
         """Returns a flat dict


### PR DESCRIPTION
This PR enables new syntax in the package list header to filter package lists. This is usefull to filter the installation of packages according some criteria, such as, the platform specs. As an example, this PR will allow the new filters: ['gpu'] key in the configuration area of the lst and the result is that the list will only be part of the stack if every filter defined in the platform yaml file do not contain the word 'none'

The following command was issued before and after this change:
```
spack write-spack-yaml -p jed -s syrah
```
No differences were shown between the two commands.

With this PR the following package list can be included in the stack file:
```yaml
gpu_packages:
  metadata: {section: packages }
  pe: [gcc_stable]
  filters: ['gpu']
  packages:
    - cuda
```
This package list will not be present in the manifest file if the platform has no gpu:
```yaml
platform:
  filters:
    gpu: none
```
More than one filter can exist in the filters list in the package list configuration header. The package list will be skipped if at least one filter if found with the property 'none' (in the platform file). Notice that this is the string 'none' and not the python built-in constant.