### PR TITLE
Corrected typo PERFIX -> PREFIX

### DIFF
--- a/stacks/syrah/templates/modules.yaml.j2
+++ b/stacks/syrah/templates/modules.yaml.j2
@@ -160,8 +160,8 @@ modules:
       intel-oneapi-compilers-classic:
         environment:
           set:
-            C_INCLUDE_PATH: ${PERFIX}/compiler/include/icc
-            CPLUS_INCLUDE_PATH: ${PERFIX}/compiler/include/icc
+            C_INCLUDE_PATH: ${PREFIX}/compiler/include/icc
+            CPLUS_INCLUDE_PATH: ${PREFIX}/compiler/include/icc
             INTEL_ROOT: ${PREFIX}
       intel-oneapi-mpi:
         environment:

--- a/stacks/syrah/templates/modules.yaml.j2
+++ b/stacks/syrah/templates/modules.yaml.j2
@@ -160,8 +160,6 @@ modules:
       intel-oneapi-compilers-classic:
         environment:
           set:
-            C_INCLUDE_PATH: ${PREFIX}/compiler/include/icc
-            CPLUS_INCLUDE_PATH: ${PREFIX}/compiler/include/icc
             INTEL_ROOT: ${PREFIX}
       intel-oneapi-mpi:
         environment:


### PR DESCRIPTION
This likely fixes the issue with the intel module where C_INCLUDE_PATH and CPLUS_INCLUDE_PATH are missing the /path/to/compiler