### PR TITLE
pkg: add fenicsx

### DIFF
--- a/stacks/syrah/syrah.yaml
+++ b/stacks/syrah/syrah.yaml
@@ -126,6 +126,7 @@ serial_packages:
         dependencies:
           - openssl@1.1.1k
     - fastqc
+    - fenics-dolfinx
     - fftw +openmp ~mpi
     - fftw ~openmp ~mpi
     - gmp


### PR DESCRIPTION
Installation tests executed on JED:
```
git clone -b v0.18.1 --single-branch git@github.com:spack/spack
source spack/share/spack/setup-env.sh
mkdir env && cd env
```
The following configuration was used:
```yaml
compilers:
- compiler:
    spec: gcc@11.3.0
    paths:
      cc: /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-x86_64_v2/gcc-8.5.0/gcc-11.3.0-yrewh277xaqlocj7zcuxnv2m4fq4p3tw/bin/gcc
      cxx: /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-x86_64_v2/gcc-8.5.0/gcc-11.3.0-yrewh277xaqlocj7zcuxnv2m4fq4p3tw/bin/g++
      f77: /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-x86_64_v2/gcc-8.5.0/gcc-11.3.0-yrewh277xaqlocj7zcuxnv2m4fq4p3tw/bin/gfortran
      fc: /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-x86_64_v2/gcc-8.5.0/gcc-11.3.0-yrewh277xaqlocj7zcuxnv2m4fq4p3tw/bin/gfortran
    flags: {}
    operating_system: rhel8
    target: x86_64
    modules: []
    environment: {}
    extra_rpaths: []
- compiler:
    spec: intel@2021.6.0
    paths:
      cc: /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-x86_64_v2/gcc-8.5.0/intel-oneapi-compilers-classic-2021.6.0-q3mi2mylw3zyuht6p72u25ruqnpptpym/bin/icc
      cxx: /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-x86_64_v2/gcc-8.5.0/intel-oneapi-compilers-classic-2021.6.0-q3mi2mylw3zyuht6p72u25ruqnpptpym/bin/icpc
      f77: /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-x86_64_v2/gcc-8.5.0/intel-oneapi-compilers-classic-2021.6.0-q3mi2mylw3zyuht6p72u25ruqnpptpym/bin/ifort
      fc: /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-x86_64_v2/gcc-8.5.0/intel-oneapi-compilers-classic-2021.6.0-q3mi2mylw3zyuht6p72u25ruqnpptpym/bin/ifort
    flags: {}
    operating_system: rhel8
    target: x86_64
    modules: []
    environment: {}
    extra_rpaths: []
repos:
  - /work/scitas-ge/erothe/epfl-scitas/scitas-spack-packages
spack:
  specs:
  - fenics-dolfinx
  view: false
upstreams:
  syrah:
    install_tree: /ssoft/spack/syrah/v1/opt/spack
```
```
export SPACK_SYSTEM_CONFIG_PATH=/home/erothe/env
spack env activate -d .
spack concretize
```
```yaml
==> Concretized fenics-dolfinx
 -   52hhz4z  fenics-dolfinx@0.6.0%gcc@11.3.0~adios2~ipo~slepc build_type=RelWithDebInfo partitioners=parmetis arch=linux-rhel8-icelake
[^]  3bkm5xg      ^boost@1.79.0%gcc@11.3.0+atomic+chrono~clanglibcpp+container~context~contract~coroutine+date_time~debug+exception~fiber+filesystem+graph~graph_parallel+icu+iostreams~json+locale+log+math~mpi+mu
ltithreaded~nowide+numpy~pic+program_options+python+random+regex+serialization+shared+signals~singlethreaded~stacktrace+system~taggedlayout+test+thread+timer~type_erasure~versionedlayout+wave cxxstd=14 patches=a
440f96,b8569d7 visibility=hidden arch=linux-rhel8-icelake
[^]  726wwu5          ^bzip2@1.0.8%gcc@11.3.0~debug~pic+shared arch=linux-rhel8-icelake
[^]  2mpysoe              ^diffutils@3.8%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  5vpx6z4                  ^libiconv@1.16%gcc@11.3.0 libs=shared,static arch=linux-rhel8-icelake
[^]  k5diea5          ^icu4c@67.1%gcc@11.3.0 cxxstd=14 arch=linux-rhel8-icelake
[^]  rgakpsa              ^python@3.10.4%gcc@11.3.0+bz2+ctypes+dbm~debug+ensurepip~libxml2+lzma~nis+optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3~ssl~tix+tkinter~ucs4+uuid+zlib patches=0d98e93,f2fd060 arch=linux-rhel8-icelake
[^]  fxnlfyo                  ^expat@2.4.8%gcc@11.3.0+libbsd arch=linux-rhel8-icelake
[^]  xl5xnw5                      ^libbsd@0.11.5%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  siuioad                          ^libmd@1.0.4%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  jivowxe                  ^gdbm@1.19%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  degusu7                      ^readline@8.1%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  nrplriu                          ^ncurses@6.2%gcc@11.3.0~symlinks+termlib abi=none arch=linux-rhel8-icelake
[^]  menettz                              ^pkgconf@1.8.0%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  f624kwq                  ^gettext@0.21%gcc@11.3.0+bzip2+curses+git~libunistring~libxml2+tar+xz arch=linux-rhel8-icelake
[^]  vdcabeo                      ^tar@1.34%gcc@11.3.0 zip=pigz arch=linux-rhel8-icelake
[^]  yop5q6r                          ^pigz@2.7%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  ixtises                              ^zlib@1.2.12%gcc@11.3.0+optimize+pic+shared patches=0d38234 arch=linux-rhel8-icelake
[^]  anc5uef                          ^xz@5.2.5%gcc@11.3.0~pic libs=shared,static arch=linux-rhel8-icelake
[^]  3nyqfa3                          ^zstd@1.5.2%gcc@11.3.0+programs compression=none libs=shared,static arch=linux-rhel8-icelake
[^]  tplfttv                  ^libffi@3.4.2%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  ogv6mk5                  ^sqlite@3.38.5%gcc@11.3.0+column_metadata+dynamic_extensions+fts~functions+rtree arch=linux-rhel8-icelake
[^]  e3lduuh                  ^tcl@8.6.12%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  6ilkq4s                  ^tk@8.6.11%gcc@11.3.0+xft+xss arch=linux-rhel8-icelake
[^]  uvsnsbc                      ^libx11@1.7.0%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  vhw4mdq                          ^inputproto@2.3.2%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  eu7ojht                              ^util-macros@1.19.3%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  qcyaxe5                          ^kbproto@1.0.7%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  piwa5b3                          ^libxcb@1.14%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  a4dnuwa                              ^libpthread-stubs@0.4%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  rp4o2zd                              ^libxau@1.0.8%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  zf6vw5b                                  ^xproto@7.0.31%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  rr3lad3                              ^libxdmcp@1.1.2%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  5h4gcmn                              ^xcb-proto@1.14.1%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  mlt3ugw                          ^perl@5.32.0%gcc@11.3.0+cpanm+shared+threads arch=linux-rhel8-icelake
[^]  alpnbg2                              ^berkeley-db@18.1.40%gcc@11.3.0+cxx~docs+stl patches=b231fcc arch=linux-rhel8-icelake
[^]  e47uvls                          ^xextproto@7.3.0%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  7td6rmc                          ^xtrans@1.3.5%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  p7hippw                      ^libxft@2.3.2%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  vunrspj                          ^fontconfig@2.13.1%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  ghcs7ho                              ^font-util@1.3.2%gcc@11.3.0 fonts=encodings,font-adobe-100dpi,font-adobe-75dpi,font-adobe-utopia-100dpi,font-adobe-utopia-75dpi,font-adobe-utopia-type1,font-alias,font-a
rabic-misc,font-bh-100dpi,font-bh-75dpi,font-bh-lucidatypewriter-100dpi,font-bh-lucidatypewriter-75dpi,font-bh-type1,font-bitstream-100dpi,font-bitstream-75dpi,font-bitstream-speedo,font-bitstream-type1,font-cro
nyx-cyrillic,font-cursor-misc,font-daewoo-misc,font-dec-misc,font-ibm-type1,font-isas-misc,font-jis-misc,font-micro-misc,font-misc-cyrillic,font-misc-ethiopic,font-misc-meltho,font-misc-misc,font-mutt-misc,font-
schumacher-misc,font-screen-cyrillic,font-sun-misc,font-winitzki-cyrillic,font-xfree86-type1 arch=linux-rhel8-icelake
[^]  dde4t7x                                  ^autoconf@2.69%gcc@11.3.0 patches=35c4492,7793209,a49dd5b arch=linux-rhel8-icelake
[^]  7jt53ih                                      ^m4@1.4.19%gcc@11.3.0+sigsegv patches=9dc5fbd,bfdffa7 arch=linux-rhel8-icelake
[^]  mzvt4yb                                          ^libsigsegv@2.13%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  mbbmkfa                                  ^automake@1.16.5%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  xvgk2jq                                  ^bdftopcf@1.0.5%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  4cty5rp                                      ^fontsproto@2.1.3%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  bnjmxns                                      ^libxfont@1.5.2%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  tdktafz                                          ^freetype@2.11.1%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  h4h6ims                                              ^libpng@1.6.37%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  ltvbab6                                          ^libfontenc@1.1.3%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  xafp55l                                  ^mkfontdir@1.0.7%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  mdvufm6                                      ^mkfontscale@1.1.2%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  7dqq33o                              ^gperf@3.1%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  24mkijs                              ^libxml2@2.9.13%gcc@11.3.0~python arch=linux-rhel8-icelake
[^]  regndck                              ^util-linux-uuid@2.37.4%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  mwmwnpw                          ^libxrender@0.9.10%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  53bt6q2                              ^renderproto@0.11.1%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  y3oim2b                      ^libxscrnsaver@1.2.2%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  tqtk3tg                          ^libxext@1.3.3%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  jhzwaeq                          ^scrnsaverproto@1.2.2%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  omnyjhj          ^py-numpy@1.22.4%gcc@11.3.0+blas+lapack patches=873745d arch=linux-rhel8-icelake
[^]  j7xc2nx              ^openblas@0.3.20%gcc@11.3.0~bignuma~consistent_fpcsr~ilp64+locking+pic+shared symbol_suffix=none threads=none arch=linux-rhel8-icelake
[^]  vp3f25g              ^py-cython@0.29.30%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  k3goyon                  ^py-pip@21.3.1%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  un7kexx                  ^py-setuptools@59.4.0%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  roxrip5                      ^py-wheel@0.37.0%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  shifgwf      ^cmake@3.23.1%gcc@11.3.0~doc~ncurses~ownlibs~qt build_type=Release arch=linux-rhel8-icelake
[^]  342lz6l          ^curl@7.83.0%gcc@11.3.0~gssapi~ldap~libidn2~librtmp~libssh~libssh2~nghttp2 libs=shared,static tls=gnutls arch=linux-rhel8-icelake
[^]  lxt62lq              ^gnutls@3.6.15%gcc@11.3.0~guile+zlib arch=linux-rhel8-icelake
[^]  dbiycnk                  ^libidn2@2.3.0%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  aza6iog                      ^libunistring@0.9.10%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  tsemgwu                  ^nettle@3.4.1%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  2sxyqyr                      ^gmp@6.2.1%gcc@11.3.0 libs=shared,static arch=linux-rhel8-icelake
[^]  6dbhnco                          ^libtool@2.4.7%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  ctm5vsy          ^libarchive@3.5.2%gcc@11.3.0+iconv compression=bz2lib,lz4,lzma,lzo2,zlib,zstd crypto=mbedtls libs=shared,static programs=none xar=expat arch=linux-rhel8-icelake
[^]  njiddla              ^lz4@1.9.3%gcc@11.3.0 libs=shared,static arch=linux-rhel8-icelake
[^]  55akfvw              ^lzo@2.10%gcc@11.3.0 libs=shared,static arch=linux-rhel8-icelake
[^]  lclkhzj              ^mbedtls@2.28.0%gcc@11.3.0+pic build_type=Release libs=static arch=linux-rhel8-icelake
[^]  vehuctx          ^libuv@1.44.1%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  6ezrwle          ^rhash@1.4.2%gcc@11.3.0 patches=093518c,3fbfe46 arch=linux-rhel8-icelake
 -   b3fc5bs      ^fenics-basix@0.6.0%gcc@11.3.0~ipo build_type=RelWithDebInfo arch=linux-rhel8-icelake
 -   xzb7mme      ^fenics-ufcx@0.6.0%gcc@11.3.0~ipo build_type=RelWithDebInfo arch=linux-rhel8-icelake
[^]  aa7kfns      ^hdf5@1.12.2%gcc@11.3.0+cxx+fortran+hl+ipo~java+mpi+shared+szip~threadsafe+tools api=default build_type=RelWithDebInfo arch=linux-rhel8-icelake
[^]  dake4rc          ^cmake@3.23.1%gcc@11.3.0~doc~ncurses+ownlibs~qt build_type=Release arch=linux-rhel8-icelake
[^]  6kxsucy              ^openssl@1.1.1k%gcc@11.3.0~docs~shared certs=system arch=linux-rhel8-icelake
[^]  moxk3fw          ^libaec@1.0.6%gcc@11.3.0~ipo+shared build_type=RelWithDebInfo arch=linux-rhel8-icelake
[^]  x2nw5xx          ^openmpi@4.1.3%gcc@11.3.0~atomics~cuda~cxx~cxx_exceptions~gpfs~internal-hwloc~java~legacylaunchers~lustre~memchecker+pmi+romio~rsh~singularity+static+vt+wrapper-rpath fabrics=ucx schedulers=slurm arch=linux-rhel8-icelake
[^]  mh53hli              ^hwloc@2.7.1%gcc@11.3.0~cairo~cuda~gl~libudev~libxml2~netloc~nvml~opencl+pci~rocm+shared arch=linux-rhel8-icelake
[^]  arqy5fg                  ^libpciaccess@0.16%gcc@11.3.0 arch=linux-rhel8-icelake
[^]  pmglqrv              ^numactl@2.0.14%gcc@11.3.0 patches=4e1d78c,62fc8a8,ff37630 arch=linux-rhel8-icelake
[^]  45duxek              ^pmix@4.2.2%gcc@11.3.0~docs+pmi_backwards_compatibility~restful arch=linux-rhel8-icelake
[^]  zh5n4m4              ^slurm@22-05-6%gcc@11.3.0~gtk~hdf5~hwloc~mariadb~pmix+readline~restd sysconfdir=PREFIX/etc arch=linux-rhel8-icelake
[^]  s64witc              ^ucx@1.12.1%gcc@11.3.0~assertions~backtrace_detail+cma~cuda+dc~debug~dm+examples~gdrcopy~ib_hw_tm~java~knem~logging+mlx5_dv+openmp+optimizations+parameter_checking+pic+rc+rdmacm~rocm+thread_multiple~ucg+ud+verbs~vfs~xpmem libs=shared,static opt=3 simd=auto arch=linux-rhel8-icelake
[^]  mkitaqm                  ^rdma-core@40.1%gcc@11.3.0~ipo build_type=RelWithDebInfo arch=linux-rhel8-icelake
[^]  y47c6az      ^parmetis@4.0.3%gcc@11.3.0~gdb~int64+ipo+shared build_type=RelWithDebInfo patches=4f89253,50ed208,704b84f arch=linux-rhel8-icelake
[^]  z3tjfxr          ^metis@5.1.0%gcc@11.3.0~gdb~int64+real64+shared build_type=Release patches=4991da9,b1225da arch=linux-rhel8-icelake
[^]  kkngpyf      ^petsc@3.17.1%gcc@11.3.0~X~batch~cgns~complex~cuda~debug+double~exodusii~fftw+fortran~giflib+hdf5~hpddm~hwloc+hypre~int64~jpeg~knl~kokkos~libpng~libyaml~memkind+metis~mkl-pardiso~mmg~moab~mpfr+mpi~mumps~openmp~p4est~parmmg~ptscotch~random123~rocm~saws~scalapack+shared~strumpack+suite-sparse+superlu-dist~tetgen~trilinos~valgrind clanguage=C arch=linux-rhel8-icelake
[^]  tk5xo2m          ^hypre@2.24.0%gcc@11.3.0~complex~cuda~debug+fortran~gptune~int64~internal-superlu~mixedint+mpi~openmp~rocm+shared~superlu-dist~unified-memory arch=linux-rhel8-icelake
[^]  mcloxmx          ^python@3.10.4%gcc@11.3.0+bz2+ctypes+dbm~debug+ensurepip~libxml2+lzma~nis+optimizations+pic+pyexpat+pythoncmd+readline+shared+sqlite3+ssl~tix+tkinter~ucs4+uuid+zlib patches=0d98e93,f2fd060 arch=linux-rhel8-icelake
[^]  h7cfpzc          ^suite-sparse@5.10.1%gcc@11.3.0~cuda~graphblas~openmp+pic~tbb arch=linux-rhel8-icelake
[^]  vt6ic6y              ^mpfr@4.1.0%gcc@11.3.0 libs=shared,static arch=linux-rhel8-icelake
[^]  ugkfe2c                  ^autoconf-archive@2022.02.11%gcc@11.3.0 patches=130cd48 arch=linux-rhel8-icelake
[^]  hdt7luc                  ^texinfo@6.5%gcc@11.3.0 patches=12f6edb,1732115 arch=linux-rhel8-icelake
[^]  sf264gk          ^superlu-dist@7.2.0%gcc@11.3.0~cuda~int64+ipo~openmp~rocm+shared build_type=RelWithDebInfo patches=8da9e21 arch=linux-rhel8-icelake
[^]  ykfovac      ^pugixml@1.11.4%gcc@11.3.0~ipo+pic+shared build_type=RelWithDebInfo arch=linux-rhel8-icelake
```
```
spack install
```
```yaml
jed-> spack install
==> Installing environment /home/erothe/env
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libiconv-1.16-5vpx6z4ezvcokdvycqtqqeenxdbyxt2v
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libmd-1.0.4-siuioad564z4ztbepjo7hbq6nas3w7db
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/pkgconf-1.8.0-menettzs6gzpqpxqekjpo7irsi7sfp25
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/zlib-1.2.12-ixtisesx64oi2zppo5uuxiqu4jathsrg
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/xz-5.2.5-anc5uefulbvgefk3fzj3zm2ryw6esnb2
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/zstd-1.5.2-3nyqfa3dhnanwcvactdfzg7oa2kpcmfp
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libffi-3.4.2-tplfttvvls3fw3lwvz3kc52km527h7ha
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/util-macros-1.19.3-eu7ojhtcb3pssoqqxgvhku4apkbkhr33
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libpthread-stubs-0.4-a4dnuwaqpyzrhz2nrawb4f7s7vgeze6v
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/xcb-proto-1.14.1-5h4gcmnegoqs7gacaexl7bncognho4jt
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/berkeley-db-18.1.40-alpnbg22suxiytbjn2uxrmvvtevlcwzq
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libsigsegv-2.13-mzvt4yblnihx6xyaxwm5oyz5lbqeeu2l
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/gperf-3.1-7dqq33om7uawkt35qrfy5lo4shp7julh
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/lz4-1.9.3-njiddlassnvjmu5q25qda4ib2ueme6mi
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/lzo-2.10-55akfvwgzvw352odxvk3o5vrch4vlb3s
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/mbedtls-2.28.0-lclkhzjkudthbivd3t2bmpfvyii2my65
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libuv-1.44.1-vehuctx4jkbkmhu7zhhjzolknxuddu7s
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/rhash-1.4.2-6ezrwlepiqrlhkfaqytbs3rlxawaqhuq
[+] /usr (external openssl-1.1.1k-6kxsucyy7nijmeyv77o7hhzj4jn5tvxh)
[+] /usr (external pmix-4.2.2-45duxekhvr5ca5ikrpsnmg4x3hhiyytk)
[+] /usr (external slurm-22-05-6-zh5n4m4ntnesggnpfbompc22chqxtwqc)
[+] /usr (external rdma-core-40.1-mkitaqmog6bxnydhfq2m2ts6lnudj47x)
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/autoconf-archive-2022.02.11-ugkfe2cjzdvhjntgn4aaxzxwx4wgce24
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/diffutils-3.8-2mpysoexkbxz77pnjnprm2ub2zf6lhvu
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libunistring-0.9.10-aza6iog4hfl4t47czzrp26katya3t7ct
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libbsd-0.11.5-xl5xnw5gqklushaidesyhyprqkiibgmf
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/ncurses-6.2-nrplriublvcsvw5zeanyvpk7qp6rc62m
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/util-linux-uuid-2.37.4-regndcksf52ev7hyhmhaw7xo663uciaq
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libpng-1.6.37-h4h6ims52fjvrz6gfm442ekzukir2t4g
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/pigz-2.7-yop5q6r47burby5b365nnqdvkgsahufg
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/tcl-8.6.12-e3lduuhodgwstdpeaudn4oikflxy7bvb
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libxml2-2.9.13-24mkijs3skge5ebkvhbgohomfi4247zm
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/xproto-7.0.31-zf6vw5b3m3rxrccowvqsfiwlsxg4fhej
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/renderproto-0.11.1-53bt6q2b2yaga3f7furltunlowrqtbqi
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/scrnsaverproto-1.2.2-jhzwaeqyrjok5k7xt7thixufs2wawoy6
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/inputproto-2.3.2-vhw4mdqydwa74mnigbecuwxx6awkxw54
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/kbproto-1.0.7-qcyaxe577cjlzlxhv3xfbwlnw6533bq6
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/xextproto-7.3.0-e47uvlsv6ks42re2lroy6n6rjrriym7r
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/xtrans-1.3.5-7td6rmcos2uw6nnyqqpn52cfduaueh4i
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/fontsproto-2.1.3-4cty5rp3hgftmshnwvyclhw5kxqfujre
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/m4-1.4.19-7jt53ihkwtoef7cwu7rbqivzifq45dpq
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/cmake-3.23.1-dake4rc5v7nkaf3dfqmtolzjn3fhzpuh
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/bzip2-1.0.8-726wwu5vgr5uyrhoqqajng74um2rve5z
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libidn2-2.3.0-dbiycnkywwz72ct2psvxnj5lnsyw2j3s
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/expat-2.4.8-fxnlfyoah7jdpd2hb4o4sui3l3btltre
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/readline-8.1-degusu7pyiwkqe4mhupw2jzmxtba2zx2
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libfontenc-1.1.3-ltvbab6zvqibjxjvrlwl3zprd2zw7x75
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libxau-1.0.8-rp4o2zdqkjadui2sj66lxyqw7xmmy5hk
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libxdmcp-1.1.2-rr3lad3gq2n6x3zdu5jigkpwbylv2ae6
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libtool-2.4.7-6dbhncocoj6qrjtf7uwbtbst2rqhwrq4
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/metis-5.1.0-z3tjfxrgolmaixochda6j4n2y32awu7i
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libaec-1.0.6-moxk3fwz3eolej6etmlw4722yac7rg5k
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/pugixml-1.11.4-ykfovacvykuywm3dh2w5jkqhokubvg4r
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/freetype-2.11.1-tdktafzwrstulpwg3ybcima3hkpw76tn
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/tar-1.34-vdcabeo6p53kp5fhafzxvlfv7gffqgzs
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libarchive-3.5.2-ctm5vsyr2jffpknvjdlpv2pvybiemnlk
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/sqlite-3.38.5-ogv6mk5pthf5r7aolxvmtr3fscr3el5g                                                                                          [21/229]
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/gdbm-1.19-jivowxequdjrjdywtttdn72ud73uto42
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libxcb-1.14-piwa5b3pycpjjabioixmaxxnydyrosxc
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libpciaccess-0.16-arqy5fgtvqfrsvnxfvcuylj5zjnv6tq4
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libxfont-1.5.2-bnjmxns5k4mhgef7zrkjugbwfpykquhk
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/mkfontscale-1.1.2-mdvufm626hi6ijqztprh5h75ujy46p3m
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/gettext-0.21-f624kwqzbmht6axphqptjji2lfgirity
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/perl-5.32.0-mlt3ugw6opvrskkllatlejkk7xej5j2j
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/hwloc-2.7.1-mh53hlicvfy5733w2gu4ksodblxnhlww
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/bdftopcf-1.0.5-xvgk2jqwtsotccciwwq3ydmwwlknoxob
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/mkfontdir-1.0.7-xafp55lvfssfh5szldj6ub3e5euhdqgk
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/autoconf-2.69-dde4t7x4mrux6hdfo3opbv2asfgush2f
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/openblas-0.3.20-j7xc2nxe6jn2zr7y52vvn6r3fn64ilxt
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libx11-1.7.0-uvsnsbcw6h5talovn5uvkjb7lsw6nrer
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/texinfo-6.5-hdt7luccbiikb5dfoch4nsxbc6w7gazy
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/automake-1.16.5-mbbmkfai6cs5apensarbuwwinmhjf4qk
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libxrender-0.9.10-mwmwnpw2ifxf5ulc36lv6i4hkk7b7w2s
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libxext-1.3.3-tqtk3tgvjclogkffcc6jpqshac6jh7fr
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/numactl-2.0.14-pmglqrv2np6s6psmoth6tb4ck6ew7zsd
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/gmp-6.2.1-2sxyqyrtrhtith6xocksolgn5milxpsl
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/font-util-1.3.2-ghcs7hotew2oehqu32pjvsw4d2a57nrg
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libxscrnsaver-1.2.2-y3oim2bjthqc6q4kqbfeer56dgt22ym3
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/ucx-1.12.1-s64witcvjnjhsabmh4ryg6gxdpltawvd
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/mpfr-4.1.0-vt6ic6yq47jkp66myqvwwfrcfy4euf2h
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/nettle-3.4.1-tsemgwui3ypx4qts3cor4qywf4dlzglb
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/fontconfig-2.13.1-vunrspjuacmlaptdxqhjcrihpgjjkxwi
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/openmpi-4.1.3-x2nw5xxjaix7giok2l2gozyw4ag33svj
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/suite-sparse-5.10.1-h7cfpzcbwtnlbmga3usunolac33shu4r
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/gnutls-3.6.15-lxt62lqxxhbn5affogcwewp7asxexaki
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/libxft-2.3.2-p7hippwiqvbcln3x2vwujlrgmmxr7lzw
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/hdf5-1.12.2-aa7kfnsbgtewcct7gtfq5har7ohbuqjb
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/hypre-2.24.0-tk5xo2mplli4oj6dwndmheoxfieayebm
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/parmetis-4.0.3-y47c6azthzxqnib5ubjqf4xnio53jtur
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/curl-7.83.0-342lz6l35b3bmsal6rzerp45kxz3fcnd
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/tk-8.6.11-6ilkq4sldkkjtusmst7j7y7kwi64aw5n
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/superlu-dist-7.2.0-sf264gkcmrxierinnjxrv4itd6wl5vif
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/cmake-3.23.1-shifgwfc7zeaxf6l3b7ylnemylh3psz7
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/python-3.10.4-rgakpsazu64lhiuzprcyou3lk6qisn2q
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/python-3.10.4-mcloxmxhlovfwwkxzyafm35bq545ntqx
==> Installing fenics-basix-0.6.0-b3fc5bsodgv7j353yxxymrtaq7hn67rf
==> No binary for fenics-basix-0.6.0-b3fc5bsodgv7j353yxxymrtaq7hn67rf found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/68/687ae53153c98facac4080dcdc7081701db1dcea8c5e7ae3feb72aec17f83304.tar.gz
==> No patches needed for fenics-basix
==> fenics-basix: Executing phase: 'cmake'
==> fenics-basix: Executing phase: 'build'
==> fenics-basix: Executing phase: 'install'
==> fenics-basix: Successfully installed fenics-basix-0.6.0-b3fc5bsodgv7j353yxxymrtaq7hn67rf
  Fetch: 0.69s.  Build: 57.49s.  Total: 58.17s.
[+] /home/erothe/spack/opt/spack/linux-rhel8-icelake/gcc-11.3.0/fenics-basix-0.6.0-b3fc5bsodgv7j353yxxymrtaq7hn67rf
==> Installing fenics-ufcx-0.6.0-xzb7mmek3nvob5rilumvrsslhr25ifsh
==> No binary for fenics-ufcx-0.6.0-xzb7mmek3nvob5rilumvrsslhr25ifsh found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/07/076fad61d406afffd41019ae1abf6da3f76406c035c772abad2156127667980e.tar.gz
==> No patches needed for fenics-ufcx
==> fenics-ufcx: Executing phase: 'cmake'
==> fenics-ufcx: Executing phase: 'build'
==> fenics-ufcx: Executing phase: 'install'
==> fenics-ufcx: Successfully installed fenics-ufcx-0.6.0-xzb7mmek3nvob5rilumvrsslhr25ifsh
  Fetch: 0.67s.  Build: 1.03s.  Total: 1.70s.
[+] /home/erothe/spack/opt/spack/linux-rhel8-icelake/gcc-11.3.0/fenics-ufcx-0.6.0-xzb7mmek3nvob5rilumvrsslhr25ifsh
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/icu4c-67.1-k5diea5q73rnmupb4jy3juzmiaqafam3
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/py-pip-21.3.1-k3goyonzkl5qc3lxifhhus5rk6rl6btf
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/petsc-3.17.1-kkngpyfpshxg3caify3jeldigfnwimhb
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/py-wheel-0.37.0-roxrip55kxwktbg7jajmrbrgwf6ftsxk
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/py-setuptools-59.4.0-un7kexxknxcdwawym33626pzcy7nv4fo
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/py-cython-0.29.30-vp3f25glb54745slitwxmh3ilg2jpdcc
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/py-numpy-1.22.4-omnyjhj5qchltacf7xbgezeq2ciuic5j
[+] /ssoft/spack/syrah/v1/opt/spack/linux-rhel8-icelake/gcc-11.3.0/boost-1.79.0-3bkm5xg3dqx7fhegvkcjxklnfifdezmy
==> Installing fenics-dolfinx-0.6.0-52hhz4z6st3lh6pa6hrcbelo56t5apvw
==> No binary for fenics-dolfinx-0.6.0-52hhz4z6st3lh6pa6hrcbelo56t5apvw found: installing from source
==> Fetching https://mirror.spack.io/_source-cache/archive/eb/eb8ac2bb2f032b0d393977993e1ab6b4101a84d54023a67206e3eac1a8d79b80.tar.gz
==> No patches needed for fenics-dolfinx
==> fenics-dolfinx: Executing phase: 'cmake'
==> fenics-dolfinx: Executing phase: 'build'
==> fenics-dolfinx: Executing phase: 'install'
==> fenics-dolfinx: Successfully installed fenics-dolfinx-0.6.0-52hhz4z6st3lh6pa6hrcbelo56t5apvw
  Fetch: 0.68s.  Build: 2m 32.44s.  Total: 2m 33.12s.
[+] /home/erothe/spack/opt/spack/linux-rhel8-icelake/gcc-11.3.0/fenics-dolfinx-0.6.0-52hhz4z6st3lh6pa6hrcbelo56t5apvw
```
