### PR TITLE
kokkos-nvcc-wrapper depends on mpi ...

### DIFF
--- a/stacks/syrah/syrah.yaml
+++ b/stacks/syrah/syrah.yaml
@@ -152,7 +152,11 @@ serial_packages:
               nvidia: +cuda +cuda_uvm cuda_arch=<cuda_arch> +wrapper
               none: ~cuda ~cuda_uvm ~rocm
         dependencies:
-          - cmake +ownlibs target=<target>
+          common:
+            - cmake +ownlibs target=<target>
+          gpu:
+            nvidia:
+              - kokkos-nvcc-wrapper~mpi
     - libarchive
     - libfabric:
         default:
@@ -965,6 +969,20 @@ mpi_packages_gpu_gcc_stable:
   dependencies: [mpi, gpu]
   filters: ["gpu"]
   packages:
+    - kokkos:
+        variants: target=<target>
+        default:
+          variants:
+            common: +openmp
+            gpu:
+              nvidia: +cuda +cuda_uvm cuda_arch=<cuda_arch> +wrapper
+              none: ~cuda ~cuda_uvm ~rocm
+        dependencies:
+          common:
+            - cmake +ownlibs target=<target>
+          gpu:
+            nvidia:
+              - kokkos-nvcc-wrapper+mpi
     - relion@4.0.1 ~mklfft:
         variants:
           gpu:


### PR DESCRIPTION
kokkos in serial pulled a openmpi on izar ...