### PR TITLE
Added Wannier90 support to VASP

### DIFF
--- a/stacks/syrah/syrah.yaml
+++ b/stacks/syrah/syrah.yaml
@@ -939,7 +939,8 @@ mpi_blas_packages:
     #       permissions:
     #         read: group
     #         group: molpro-soft
-    - vasp@6.3.2 +hdf5 +scalapack +shmem:
+    - vasp@6.3.2:
+        variants: +hdf5 +scalapack +shmem +wannier90
         default:
           buildable: true
           permissions:
@@ -947,7 +948,8 @@ mpi_blas_packages:
             group: vasp-soft
         dependencies:
           - hdf5 +mpi ~ipo
-    - vasp@6.4.1 +hdf5 +scalapack +shmem:
+    - vasp@6.4.1:
+        variants: +hdf5 +scalapack +shmem +wannier90
         default:
           buildable: true
           permissions:


### PR DESCRIPTION
This depends on an updated vasp recipe (already in our repo-externals)
The change comes following a ticket