### PR TITLE
Unblacklist non external openssl

### DIFF
--- a/stacks/syrah/templates/modules.yaml.j2
+++ b/stacks/syrah/templates/modules.yaml.j2
@@ -50,7 +50,7 @@ modules:
         - lmod
         - m4
         - openjdk
-        - openssl
+        - openssl@{{tokens['openssl_version']}}
         - perl
         - pmix
         - rdma-core


### PR DESCRIPTION
This is to be able to load openssl when loading python