### PR TITLE
adding petsc+int64

### DIFF
--- a/stacks/syrah/syrah.yaml
+++ b/stacks/syrah/syrah.yaml
@@ -1146,7 +1146,6 @@ mpi_blas_python_packages_gcc_stable:
 mpi_blas_python_packages_petsc_gcc_stable:
   metadata: { section: packages }
   pe: [gcc_stable]
-  filters: ['gpu'] # This filter is only for backward compatibility
   dependencies: [mpi, blas, python3, gpu]
   packages:
     - petsc:
@@ -1156,6 +1155,15 @@ mpi_blas_python_packages_petsc_gcc_stable:
             gpu:
               nvidia: +cuda cuda_arch=<cuda_arch>
               none: ~cuda
+        variants: ~int64
+        dependencies:
+          common:
+            - hdf5 +ipo +mpi
+          gpu:
+            nvidia: [suite-sparse +cuda]
+            none: []
+    - petsc:
+        variants: +int64
         dependencies:
           common:
             - hdf5 +ipo +mpi


### PR DESCRIPTION
```
  filters: ['gpu'] # This filter is only for backward compatibility
```
It was to not break the v1 but I forgot it and it made it not install petsc with gcc on v2 and v3