### PR TITLE
Added py-macs3 (installs v3.0.1)

### DIFF
--- a/stacks/syrah/syrah.yaml
+++ b/stacks/syrah/syrah.yaml
@@ -536,6 +536,7 @@ serial_packages_python_blas:
     #- bcl2fastq2
     - py-biopython
     - py-macs2
+    - py-macs3
     - py-pybigwig
 
 serial_packages_python_blas_gcc_stable:


### PR DESCRIPTION
This version corrects an issue with a dependency of py-macs. `py-cykhash` was not listed as a dependency of py-macs3 (s/3/2/) on the previous install and this causes issues for certain parts of macs3. (e.g. INC0636751, if you want to take a look).

This depends on MR: https://github.com/epfl-scitas/scitas-spack-packages/pull/25

I compiled this a few minutes back and both versions (gnu/intel) work with a test case from the user