### PR TITLE
Added the new py-macs3 to the gcc stack

### DIFF
--- a/stacks/syrah/syrah.yaml
+++ b/stacks/syrah/syrah.yaml
@@ -559,6 +559,7 @@ serial_packages_python_blas_gcc_stable:
     - py-h5py ^hdf5 ~mpi +ipo:
         modules:
           autoload: direct
+    - py-macs3
     - py-scikit-learn
     - py-scipy:
         activated: True


### PR DESCRIPTION
This was updated following the discussion earlier on today.

It no longer depends on a py-setuptools newer than what we have on our stack
It does not compile on the Intel side of things.