### PR TITLE
Added ansys@2024R2

### DIFF
--- a/stacks/syrah/syrah.yaml
+++ b/stacks/syrah/syrah.yaml
@@ -694,8 +694,11 @@ external_packages:
             prefix: <external_prefix>/ansys/2022R2/v222
           - spec: ansys@2024R1 %<core_compiler>
             prefix: <external_prefix>/ansys/2024R1/v241
+          - spec: ansys@2024R2 %<core_compiler>
+            prefix: <external_prefix>/ansys/2024R2/v242
     - ansys@2022R2
     - ansys@2024R1
+    - ansys@2024R2
     - cfdplusplus:
         default:
           buildable: false


### PR DESCRIPTION
In case you think it's worth it to install the new version on the old stack. If so, I'll PR it on syrah.v2 as well, to have it on helvetios (where we've been asked for it, but I told the user to `slmodules -r future`)